### PR TITLE
PHPCSDev: account for new PHPCS backfill

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -22,6 +22,7 @@
         <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
         <exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.t_bad_characterFound"/>
     </rule>
 
 


### PR DESCRIPTION
PHPCS 3.5.0 will backfill the new PHP 7.4 `T_BAD_CHARACTER` token.

Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/commit/96f878fa42dde8c4e68fe4a62789275ed0d61195