### PR TITLE
Composer: make the version requirement for the PHPCS plugin more flexible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,16 @@
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.0.2",
         "phpcompatibility/php-compatibility" : "^9.0.0",
-        "dealerdirect/phpcodesniffer-composer-installer" : "^0.5"
+        "dealerdirect/phpcodesniffer-composer-installer" : ">=0.3"
     },
     "require-dev" : {
         "roave/security-advisories" : "dev-master",
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "jakub-onderka/php-console-highlighter": "^0.4"
+    },
+    "conflict": {
+        "dealerdirect/phpcodesniffer-composer-installer": "0.4.0"
     },
     "bin": [
         "bin/phpcs-check-feature-completeness"


### PR DESCRIPTION
... to prevent conflicts with projects, be it external standards or end-user projects, which require the plugin themselves as well.

Note: Version `0.4.0` is excluded from being installed due to a bug which made it far less usable.

Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases