### PR TITLE
Composer: make the version requirement for the Composer PHPCS plugin more flexible, take two

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,13 @@
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.0.2",
         "phpcompatibility/php-compatibility" : "^9.0.0",
-        "dealerdirect/phpcodesniffer-composer-installer" : ">=0.3"
+        "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5.0"
     },
     "require-dev" : {
         "roave/security-advisories" : "dev-master",
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "jakub-onderka/php-console-highlighter": "^0.4"
-    },
-    "conflict": {
-        "dealerdirect/phpcodesniffer-composer-installer": "0.4.0"
     },
     "bin": [
         "bin/phpcs-check-feature-completeness"


### PR DESCRIPTION
Further iteration on earlier fix as pulled in #7, now no longer using unbound restraints.

Note: Version `0.4.0` is excluded from being installed due to a [bug](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/issues/33) which made it far less usable.

Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases