### PR TITLE
Travis: PHP 7.4 is no longer allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,13 +86,17 @@ jobs:
     # PHPCS is only compatible with PHP 7.3 as of version 3.3.1.
     - php: 7.3
       env: PHPCS_VERSION="3.3.1"
+    - php: "7.4snapshot"
+      env: PHPCS_VERSION="dev-master"
     # PHPCS is only compatible with PHP 7.4 as of version 3.5.0.
     - php: "7.4snapshot"
-      env: PHPCS_VERSION=dev-master"
+      env: PHPCS_VERSION="3.5.0"
+    - php: "nightly"
+      env: PHPCS_VERSION="n/a" LINT=1
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
+    - php: "nightly"
 
 
 before_install:
@@ -102,16 +106,19 @@ before_install:
   # On stable PHPCS versions, allow for PHP deprecation notices.
   # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_BRANCH != "dev-master" ]]; then
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && "$PHPCS_VERSION" != "dev-master" && "$PHPCS_VERSION" != "n/a" ]]; then
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 
   - export XMLLINT_INDENT="    "
 
   # Set up test environment using Composer.
-  - composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
   - |
-    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" ]]; then
+    if [[ $PHPCS_VERSION != "n/a" ]]; then
+      composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
+    fi
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" || $PHPCS_VERSION == "n/a" ]]; then
       # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
       composer remove --dev phpunit/phpunit --no-update --no-scripts
     elif [[ "$PHPCS_VERSION" < "3.1.0" ]]; then
@@ -141,4 +148,4 @@ script:
   - if [[ "$LINT" == "1" ]]; then composer validate --no-check-all --strict; fi
 
   # Run the unit tests.
-  - composer run-tests
+  - if [[ $PHPCS_VERSION != "n/a" ]]; then composer run-tests; fi

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PHPCSDevTools for developers of PHP_CodeSniffer sniffs
 [![Last Commit to Unstable](https://img.shields.io/github/last-commit/PHPCSStandards/PHPCSDevTools/develop.svg)](https://github.com/PHPCSStandards/PHPCSDevTools/commits/develop)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/phpcsdevtools.svg?maxAge=3600)](https://packagist.org/packages/phpcsstandards/phpcsdevtools)
-[![Tested on PHP 5.4 to 7.4 snapshot](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4snapshot-brightgreen.svg?maxAge=2419200)](https://travis-ci.com/PHPCSStandards/PHPCSDevTools)
+[![Tested on PHP 5.4 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4snapshot%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://travis-ci.com/PHPCSStandards/PHPCSDevTools)
 
 [![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsdevtools/license.png)](https://github.com/PHPCSStandards/PHPCSDevTools/blob/master/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)


### PR DESCRIPTION
... as it is coming out in less than a month's time.

... and add a build against `nightly`, which _is_ allowed to fail. This build will - for now - only lint the PHP files and run the "feature complete" integration test.
The unit tests are skipped for the time being, as the PHPCS native unit test suite is not yet compatible with PHP 8.