### PR TITLE
Readme: fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Installation
 
 Run the following from the root of your project:
 ```bash
-composer require phpcsstandards/phpcsdevtools:^1.0
+composer require --dev phpcsstandards/phpcsdevtools:^1.0
 ```
 
 ### Composer Global Installation


### PR DESCRIPTION
When using a project based install, this tool should normally be installed as a `--dev` tool.

[skip-ci]