### PR TITLE
PHPCSDev ruleset: disallow Yoda conditions

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -110,6 +110,9 @@
         <severity>0</severity>
     </rule>
 
+    <!-- Disallow Yoda conditions. -->
+    <rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
+
 
     <!--
     ####################################################################

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ PHPCS itself can also display similar information using the `-vv` or `-vvv` verb
 
 Once this project is installed, you will see a new `PHPCSDev` ruleset in the list of installed standards when you run `phpcs -i`.
 
-**Important: This ruleset currently requires PHP_CodeSniffer >= `3.4.0+`.**
+**Important: This ruleset currently requires PHP_CodeSniffer >= `3.5.0+`.**
 
 > As sniffs developers will mostly work with the latest version of PHP_CodeSniffer, this shouldn't cause any problems.
 >


### PR DESCRIPTION
This sniff was introduced in PHPCS 3.5.0.