### PR TITLE
CheckSniffCompleteness: change namespace

### DIFF
--- a/Scripts/CheckSniffCompleteness.php
+++ b/Scripts/CheckSniffCompleteness.php
@@ -8,7 +8,7 @@
  * @link      https://github.com/PHPCSStandards/PHPCSDevTools
  */
 
-namespace PHPCSStandards\Scripts;
+namespace PHPCSDevTools\Scripts;
 
 /**
  * Check that each sniff is feature complete, i.e. has unit tests and documentation.

--- a/Scripts/FileList.php
+++ b/Scripts/FileList.php
@@ -8,7 +8,7 @@
  * @link      https://github.com/PHPCSStandards/PHPCSDevTools
  */
 
-namespace PHPCSStandards\Scripts;
+namespace PHPCSDevTools\Scripts;
 
 use FilesystemIterator;
 use RecursiveDirectoryIterator;

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -40,5 +40,5 @@ if (is_file(__DIR__.'/../autoload.php') === true) {
     require_once __DIR__ . '/../Scripts/CheckSniffCompleteness.php';
 }
 
-$validate = new PHPCSStandards\Scripts\CheckSniffCompleteness();
+$validate = new PHPCSDevTools\Scripts\CheckSniffCompleteness();
 $validate->validate();


### PR DESCRIPTION
Use the package name, rather than the organization name.