### PR TITLE
PHPCSDev ruleset: no need for the namespace

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDev" namespace="PHPCSStandards\PHPCSDev" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDev" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 
     <description>A PSR-2 based standard for use by sniff developers to check the code style of external PHPCS standards</description>
 


### PR DESCRIPTION
As the `PHPCSDev` ruleset - at this time - does not contain any native sniffs, there is no need to have the namespace declared.

If/when any native sniffs would be added, this can be revisited.