### PR TITLE
PHPCSDev ruleset: switch over to PSR12 and other minor tweaks

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDev" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <description>A PSR-2 based standard for use by sniff developers to check the code style of external PHPCS standards</description>
+    <description>A PSR-12 based standard for use by sniff developers to check the code style of external PHPCS standards</description>
 
     <!--
     ####################################################################
@@ -28,10 +28,18 @@
 
     <!--
     ####################################################################
-    Code style: Check style for compliance with PSR2.
+    Code style: Check style for compliance with PSR12.
     ####################################################################
     -->
-    <rule ref="PSR2"/>
+    <rule ref="PSR12">
+        <!-- As PHP 5.4 is the minimum supported PHP version for PHP_CodeSniffer and
+             most external standards, adding constant visibility is not (yet) an option. -->
+        <exclude name="PSR12.Properties.ConstantVisibility"/>
+
+        <!-- Allow for the first condition of a multi-line control structure to be on the same line
+             as the control structure keyword. -->
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/>
+    </rule>
 
 
     <!--
@@ -60,7 +68,7 @@
     ####################################################################
     -->
 
-    <!-- PSR2 appears to ignore blank lines for superfluous whitespace and in several other places. Let's fix that. -->
+    <!-- PSR12 appears to ignore blank lines for superfluous whitespace and in several other places. Let's fix that. -->
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>
@@ -89,11 +97,7 @@
         </properties>
     </rule>
 
-    <rule ref="Generic.PHP.LowerCaseType"/>
     <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing"/>
-    <rule ref="PSR12.Classes.ClassInstantiation"/>
-    <rule ref="PSR12.Keywords.ShortFormTypeKeywords"/>
-    <rule ref="PSR12.Operators.OperatorSpacing"/>
 
     <!-- Align the equal operator in assignment blocks. -->
     <rule ref="Generic.Formatting.MultipleStatementAlignment">

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Often, sniff repos will use the code style of the standard they are adding. Howe
 So for those repos which need a basic standard which will still keep their code-base consistent, this standard should be useful.
 
 The standard checks your code against the following:
-* Compliance with [PSR-2](https://www.php-fig.org/psr/psr-2/).
+* Compliance with [PSR-12](https://www.php-fig.org/psr/psr-12/), with a  few exceptions.
 * Use of camelCase variable and function names.
 * Use of normalized arrays.
 * All files, classes, functions and properties are documented with a docblock and contain the minimally needed information.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -32,7 +32,14 @@
     #############################################################################
     -->
 
-    <rule ref="PHPCSDev"/>
+    <rule ref="PHPCSDev">
+        <!-- Allow for the file docblock on the line directly following the PHP open tag.
+             As the sniff in PHPCS does not use modular error codes (yet - see PR #2729),
+             the complete error code needs to be disabled, not just the bit involving
+             the file docblocks.
+        -->
+        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
+    </rule>
 
     <!-- Set minimum PHP version supported to PHP 5.4. -->
     <config name="testVersion" value="5.4-"/>


### PR DESCRIPTION
This switches the basis of the `PHPCSDev` ruleset over to PSR12 with a few, selective exceptions:
* Constant visibility will not be demanded as the minimum PHP requirement of PHPCS is PHP 5.4 and constant visibility did not become available until PHP 7.1.
* The first condition of a multi-line control structure is allowed to be on the same line as the control structure keyword (PSR2 style).

Includes updating the Readme to reflect this change.
Includes removing some individual rule includes which are now already included via PSR12.

**Note:** PSR12 enforces a blank line between each of the file header blocks.
This rule can currently not (yet) be turned off in a modular way, i.e. for just one block. It is either on or off.
This rule conflicts with the common practice of having no blank line between the PHP open tag and the file docblock.
To turn this rule off, add `<exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>` to the project specific ruleset, like is done in this PR for the PHPCSDevTools native project ruleset.