### PR TITLE
PHPCSDev ruleset: allow for more than one `@since` tag

### DIFF
--- a/PHPCSDev/ruleset.xml
+++ b/PHPCSDev/ruleset.xml
@@ -174,6 +174,9 @@
 
         <!-- Having a @see or @internal tag before the @category tag is fine. -->
         <exclude name="PEAR.Commenting.ClassComment.CategoryTagOrder"/>
+
+        <!-- Using @since for class changelog demands multiple tags. -->
+        <exclude name="PEAR.Commenting.ClassComment.DuplicateSinceTag"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
... to document a class's changelog.