### PR TITLE
CI: switch to fork of Parallel-lint package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require-dev" : {
         "roave/security-advisories" : "dev-master",
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0",
-        "jakub-onderka/php-parallel-lint": "^1.0",
-        "jakub-onderka/php-console-highlighter": "^0.4",
+        "php-parallel-lint/php-parallel-lint": "^1.0",
+        "php-parallel-lint/php-console-highlighter": "^0.4",
         "phpcsstandards/phpcsdevcs": "^1.0.0"
     },
     "bin": [
@@ -36,7 +36,7 @@
     ],
     "scripts" : {
         "lint": [
-            "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "check-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"


### PR DESCRIPTION
... as the original appears not to be maintained anymore and is not compatible with PHP 7.4.