### PR TITLE
Composer: set minimum Composer PHPCS plugin dependency version to `0.4.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.0.2",
-        "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5 || ^0.6.2"
+        "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2"
     },
     "require-dev" : {
         "roave/security-advisories" : "dev-master",


### PR DESCRIPTION
Support for the `installed_paths` being set when the plugin is a requirement of a standard itself, was only added in version `0.4.0` and a pertinent bug in this feature was fixed in `0.4.1`, which effectively makes version `0.4.1` the minimum workable version for both use as a stand-alone standard, as well as when this standard is required as a dependency.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.4.0
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.4.1