### PR TITLE
QA/CS: update PHPCSDevCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "phpcsstandards/phpcsdevcs": "^1.0"
+        "phpcsstandards/phpcsdevcs": "^1.1.1"
     },
     "bin": [
         "bin/phpcs-check-feature-completeness"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,9 +44,6 @@
     <!-- Set minimum PHP version supported to PHP 5.4. -->
     <config name="testVersion" value="5.4-"/>
 
-    <!-- Enforce short arrays. -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-
 
     <!--
     #############################################################################


### PR DESCRIPTION
The new `1.1.x` version already includes a check for short array syntax, so we can remove that from our own ruleset.