### PR TITLE
Debug/TokenList: various tweaks

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -81,14 +81,15 @@ class TokenListSniff implements Sniff
 
         $ptrPadding  = \max(3, \strlen($last));
         $linePadding = \strlen($tokens[$last]['line']);
+        $sep         = ' | ';
 
         echo \PHP_EOL;
         echo \str_pad('Ptr', $ptrPadding, ' ', \STR_PAD_BOTH),
-            ' :: ', \str_pad('Ln', ($linePadding + 1), ' ', \STR_PAD_BOTH),
-            ' :: ', \str_pad('Col', 4, ' ', \STR_PAD_BOTH),
-            ' :: ', 'Cond',
-            ' :: ', \str_pad('Token Type', 26), // Longest token type name is 26 chars.
-            ' :: [len]: Content', \PHP_EOL;
+            $sep, \str_pad('Ln', ($linePadding + 1), ' ', \STR_PAD_BOTH),
+            $sep, \str_pad('Col', 4, ' ', \STR_PAD_BOTH),
+            $sep, 'Cond',
+            $sep, \str_pad('Token Type', 26), // Longest token type name is 26 chars.
+            $sep, '[len]: Content', \PHP_EOL;
 
         echo \str_repeat('-', ($ptrPadding + $linePadding + 35 + 16 + 18)), \PHP_EOL;
 
@@ -111,18 +112,18 @@ class TokenListSniff implements Sniff
                     $content = \str_replace("\t", '\t', $content);
                 }
                 if (isset($token['orig_content'])) {
-                    $content .= ' :: Orig: ' . \str_replace("\t", '\t', $token['orig_content']);
+                    $content .= $sep . 'Orig: ' . \str_replace("\t", '\t', $token['orig_content']);
                 }
             }
 
             $conditionCount = \count($token['conditions']);
 
             echo \str_pad($ptr, $ptrPadding, ' ', \STR_PAD_LEFT),
-                ' :: L', \str_pad($token['line'], $linePadding, '0', \STR_PAD_LEFT),
-                ' :: C', \str_pad($token['column'], 3, ' ', \STR_PAD_LEFT),
-                ' :: CC', \str_pad($conditionCount, 2, ' ', \STR_PAD_LEFT),
-                ' :: ', \str_pad($token['type'], 26), // Longest token type name is 26 chars.
-                ' :: [', $token['length'], ']: ', $content, \PHP_EOL;
+                $sep, 'L', \str_pad($token['line'], $linePadding, '0', \STR_PAD_LEFT),
+                $sep, 'C', \str_pad($token['column'], 3, ' ', \STR_PAD_LEFT),
+                $sep, 'CC', \str_pad($conditionCount, 2, ' ', \STR_PAD_LEFT),
+                $sep, \str_pad($token['type'], 26), // Longest token type name is 26 chars.
+                $sep, '[', $token['length'], ']: ', $content, \PHP_EOL;
         }
 
         // Only do this once per file.

--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -88,6 +88,7 @@ class TokenListSniff implements Sniff
             $sep, \str_pad('Ln', ($linePadding + 1), ' ', \STR_PAD_BOTH),
             $sep, 'Col ',
             $sep, 'Cond',
+            $sep, '( #)',
             $sep, \str_pad('Token Type', 26), // Longest token type name is 26 chars.
             $sep, '[len]: Content', \PHP_EOL;
 
@@ -116,10 +117,16 @@ class TokenListSniff implements Sniff
                 }
             }
 
+            $parenthesesCount = 0;
+            if (isset($token['nested_parenthesis'])) {
+                $parenthesesCount = \count($token['nested_parenthesis']);
+            }
+
             echo \str_pad($ptr, $ptrPadding, ' ', \STR_PAD_LEFT),
                 $sep, 'L', \str_pad($token['line'], $linePadding, '0', \STR_PAD_LEFT),
                 $sep, 'C', \str_pad($token['column'], 3, ' ', \STR_PAD_LEFT),
                 $sep, 'CC', \str_pad($token['level'], 2, ' ', \STR_PAD_LEFT),
+                $sep, '(', \str_pad($parenthesesCount, 2, ' ', \STR_PAD_LEFT), ')',
                 $sep, \str_pad($token['type'], 26), // Longest token type name is 26 chars.
                 $sep, '[', $token['length'], ']: ', $content, \PHP_EOL;
         }

--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -86,7 +86,7 @@ class TokenListSniff implements Sniff
         echo \PHP_EOL;
         echo \str_pad('Ptr', $ptrPadding, ' ', \STR_PAD_BOTH),
             $sep, \str_pad('Ln', ($linePadding + 1), ' ', \STR_PAD_BOTH),
-            $sep, \str_pad('Col', 4, ' ', \STR_PAD_BOTH),
+            $sep, 'Col ',
             $sep, 'Cond',
             $sep, \str_pad('Token Type', 26), // Longest token type name is 26 chars.
             $sep, '[len]: Content', \PHP_EOL;
@@ -116,12 +116,10 @@ class TokenListSniff implements Sniff
                 }
             }
 
-            $conditionCount = \count($token['conditions']);
-
             echo \str_pad($ptr, $ptrPadding, ' ', \STR_PAD_LEFT),
                 $sep, 'L', \str_pad($token['line'], $linePadding, '0', \STR_PAD_LEFT),
                 $sep, 'C', \str_pad($token['column'], 3, ' ', \STR_PAD_LEFT),
-                $sep, 'CC', \str_pad($conditionCount, 2, ' ', \STR_PAD_LEFT),
+                $sep, 'CC', \str_pad($token['level'], 2, ' ', \STR_PAD_LEFT),
                 $sep, \str_pad($token['type'], 26), // Longest token type name is 26 chars.
                 $sep, '[', $token['length'], ']: ', $content, \PHP_EOL;
         }

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
@@ -45,12 +45,12 @@ class TokenListUnitTest extends UtilityMethodTestCase
         $this->assertNotEmpty($output);
 
         $expected  = "\n";
-        $expected .= 'Ptr :: Ln :: Col  :: Cond :: Token Type                 :: [len]: Content' . "\n";
+        $expected .= 'Ptr | Ln | Col  | Cond | Token Type                 | [len]: Content' . "\n";
         $expected .= '-------------------------------------------------------------------------' . "\n";
-        $expected .= '  0 :: L1 :: C  1 :: CC 0 :: T_OPEN_TAG                 :: [5]: <?php' . "\n\n";
-        $expected .= '  1 :: L2 :: C  1 :: CC 0 :: T_WHITESPACE               :: [0]: ' . "\n\n";
-        $expected .= '  2 :: L3 :: C  1 :: CC 0 :: T_FUNCTION                 :: [8]: function' . "\n";
-        $expected .= '  3 :: L3 :: C  9 :: CC 0 :: T_WHITESPACE               :: [0]: ' . "\n\n";
+        $expected .= '  0 | L1 | C  1 | CC 0 | T_OPEN_TAG                 | [5]: <?php' . "\n\n";
+        $expected .= '  1 | L2 | C  1 | CC 0 | T_WHITESPACE               | [0]: ' . "\n\n";
+        $expected .= '  2 | L3 | C  1 | CC 0 | T_FUNCTION                 | [8]: function' . "\n";
+        $expected .= '  3 | L3 | C  9 | CC 0 | T_WHITESPACE               | [0]: ' . "\n\n";
 
         $this->assertSame($expected, $output);
     }

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
@@ -45,12 +45,12 @@ class TokenListUnitTest extends UtilityMethodTestCase
         $this->assertNotEmpty($output);
 
         $expected  = "\n";
-        $expected .= 'Ptr | Ln | Col  | Cond | Token Type                 | [len]: Content' . "\n";
+        $expected .= 'Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content' . "\n";
         $expected .= '-------------------------------------------------------------------------' . "\n";
-        $expected .= '  0 | L1 | C  1 | CC 0 | T_OPEN_TAG                 | [5]: <?php' . "\n\n";
-        $expected .= '  1 | L2 | C  1 | CC 0 | T_WHITESPACE               | [0]: ' . "\n\n";
-        $expected .= '  2 | L3 | C  1 | CC 0 | T_FUNCTION                 | [8]: function' . "\n";
-        $expected .= '  3 | L3 | C  9 | CC 0 | T_WHITESPACE               | [0]: ' . "\n\n";
+        $expected .= '  0 | L1 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [5]: <?php' . "\n\n";
+        $expected .= '  1 | L2 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [0]: ' . "\n\n";
+        $expected .= '  2 | L3 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [8]: function' . "\n";
+        $expected .= '  3 | L3 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [0]: ' . "\n\n";
 
         $this->assertSame($expected, $output);
     }


### PR DESCRIPTION
### Debug/TokenList: change the column separator from `::` to `|`

### Debug/TokenList: small simplifications

* The `level` index already contains the condition count, so no need for doing a `count()` within the sniff.
* No need to use `str_pad()` for a title with fixed length.

### Debug/TokenList: add column showing nr of nested parentheses

This is based on a count of the `nested_parenthesis` index.

Includes adjusted unit tests.

