### PR TITLE
QA: minor tweak

### DIFF
--- a/Scripts/CheckSniffCompleteness.php
+++ b/Scripts/CheckSniffCompleteness.php
@@ -258,7 +258,7 @@ class CheckSniffCompleteness
         foreach ($args as $arg) {
             if (\strpos($arg, '--exclude=') === 0) {
                 $exclude = \substr($arg, 10);
-                if ($exclude === '') {
+                if (empty($exclude)) {
                     $this->excludedDirs = [];
                     continue;
                 }


### PR DESCRIPTION
On failure, `substr()` can return `false` or an empty string and as of PHP 8.0, that will be reduced to just an empty string.

This simple tweak hardens the code just in case `false` would be returned.