### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -5,6 +5,8 @@ on:
   # Prevent the build from running when there are only irrelevant changes.
   push:
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   checkcs:

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         run: |
@@ -56,7 +57,11 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        run: composer check-cs
+        continue-on-error: true
+        run: composer check-cs -- --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -4,11 +4,7 @@ on:
   # Run on all pushes and on all pull requests.
   # Prevent the build from running when there are only irrelevant changes.
   push:
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   checkcs:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches-ignore:
       - stable
-    paths-ignore:
-      - '**.md'
 
 jobs:
   #### QUICK TEST STAGE ####

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches-ignore:
       - stable
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### QUICK TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - stable
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         run: |
@@ -107,7 +108,7 @@ jobs:
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'
-        run: composer lint
+        run: composer lint -- --checkstyle | cs2pr
 
       # Check that any sniffs available are feature complete.
       # This also acts as an integration test for the feature completeness script,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - stable
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   #### TEST STAGE ####


### PR DESCRIPTION
### GH Actions: don't ignore markdown-only changes

... as it doesn't play nice with required statuses.

### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

### GH Actions: report CS violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

### GH Actions: report linting violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

