### PR TITLE
Docs: minor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ _Nothing yet._
 
 ### Changed
 * The `master` branch has been renamed to `stable`.
-* The version requirements for the [Dealerdirect Composer PHPCS plugin] have been widened to allow installation of releases from the `0.7.x` range, which brings compatibility with Composer 2.0.
+* The version requirements for the [Composer PHPCS plugin] have been widened to allow installation of releases from the `0.7.x` range, which brings compatibility with Composer 2.0.
 * Miscellaneous updates to the development environment and CI scripts.
 
 
@@ -41,4 +41,4 @@ Initial release containing:
 [1.1.0]: https://github.com/PHPCSStandards/PHPCSDevTools/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/PHPCSStandards/PHPCSDevTools/compare/1.0.0...1.0.1
 
-[Dealerdirect Composer PHPCS plugin]: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/
+[Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Installation
 
 Run the following from the root of your project:
 ```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require --dev phpcsstandards/phpcsdevtools:^1.0
 ```
 
@@ -43,6 +44,7 @@ composer require --dev phpcsstandards/phpcsdevtools:^1.0
 
 If you work on several different sniff repos, you may want to install this toolset globally:
 ```bash
+composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer global require --dev phpcsstandards/phpcsdevtools:^1.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-instal
 composer global require --dev phpcsstandards/phpcsdevtools:^1.0
 ```
 
-Composer will automatically install dependencies and register the PHPCSDebug standard with PHP_CodeSniffer using the [DealerDirect Composer PHPCS plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/).
+Composer will automatically install dependencies and register the PHPCSDebug standard with PHP_CodeSniffer using the [Composer PHPCS plugin](https://github.com/PHPCSStandards/composer-installer).
 
 
 ### Stand-alone Installation


### PR DESCRIPTION
### README: update for Composer 2.2

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is a non-dev requirement for VIPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit adds the CLI command to set those permissions to the installation instructions.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

### Update references to the Composer plugin

The Composer plugin has a new home.

Ref: https://github.com/PHPCSStandards/composer-installer/issues/146