### PR TITLE
Composer: update PHP Parallel Lint and Console Highlighter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require-dev" : {
         "roave/security-advisories" : "dev-master",
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3.1",
-        "php-parallel-lint/php-console-highlighter": "^0.5",
+        "php-parallel-lint/php-parallel-lint": "^1.3.2",
+        "php-parallel-lint/php-console-highlighter": "^1.0.0",
         "phpcsstandards/phpcsdevcs": "^1.1.3",
         "phpcsstandards/phpcsutils" : "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "prefer-stable": true,
     "scripts" : {
         "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
         ],
         "check-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"


### PR DESCRIPTION
### Composer: update PHP Parallel Lint and Console Highlighter

PHP Console Highlighter has released version `1.0.0` and PHP Parallel Lint version `1.3.2` is the first PHP Parallel Lint version which supports PHP Console Highlighter `1.0.0`.

As the minimum supported PHP version is still PHP 5.3 for both, we can safely update both dependency requirements.

Refs:
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v1.0.0
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.2

### GH Actions: show deprecations when linting

While rare, there are some deprecations which PHP can show when a file is being linted.
By default these are ignored by PHP-Parallel-Lint.

Apparently though, there is an option to show them (wasn't documented until recently), so let's turn that option on.