### PR TITLE
Debug/Tokenlist: minor readability improvement

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -128,7 +128,7 @@ class TokenListSniff implements Sniff
                 $sep, 'CC', \str_pad($token['level'], 2, ' ', \STR_PAD_LEFT),
                 $sep, '(', \str_pad($parenthesesCount, 2, ' ', \STR_PAD_LEFT), ')',
                 $sep, \str_pad($token['type'], 26), // Longest token type name is 26 chars.
-                $sep, '[', $token['length'], ']: ', $content, \PHP_EOL;
+                $sep, '[', \str_pad($token['length'], 3, ' ', \STR_PAD_LEFT), ']: ', $content, \PHP_EOL;
         }
 
         // Only do this once per file.

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
@@ -39,10 +39,10 @@ class TokenListUnitTest extends UtilityMethodTestCase
         $expected  = "\n";
         $expected .= 'Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content' . "\n";
         $expected .= '-------------------------------------------------------------------------' . "\n";
-        $expected .= '  0 | L1 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [5]: <?php' . "\n\n";
-        $expected .= '  1 | L2 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [0]: ' . "\n\n";
-        $expected .= '  2 | L3 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [8]: function' . "\n";
-        $expected .= '  3 | L3 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [0]: ' . "\n\n";
+        $expected .= '  0 | L1 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  5]: <?php' . "\n\n";
+        $expected .= '  1 | L2 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  0]: ' . "\n\n";
+        $expected .= '  2 | L3 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [  8]: function' . "\n";
+        $expected .= '  3 | L3 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [  0]: ' . "\n\n";
 
         $this->expectOutputString($expected);
         $this->setOutputCallback([$this, 'normalizeLineEndings']);


### PR DESCRIPTION
Pad the content length to three characters to prevent the display of the content jumping depending on the length.

Includes updated unit tests.