### PR TITLE
GH Actions/CSQA: move the composer validate check up

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -33,6 +33,11 @@ jobs:
           coverage: none
           tools: cs2pr
 
+      # Validate the composer.json file.
+      # @link https://getcomposer.org/doc/03-cli.md#validate
+      - name: Validate Composer installation
+        run: composer validate --no-check-all --strict
+
       - name: 'Composer: adjust dependencies'
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
@@ -70,8 +75,3 @@ jobs:
 
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml
-
-      # Validate the composer.json file.
-      # @link https://getcomposer.org/doc/03-cli.md#validate
-      - name: Validate Composer installation
-        run: composer validate --no-check-all --strict


### PR DESCRIPTION
... to be run before making adjustments to the `composer.json` file.