### PR TITLE
GH Actions: auto-deploy website on push to `stable`

### DIFF
--- a/.github/build/Website.php
+++ b/.github/build/Website.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools\GHPages
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Build;
+
+use RuntimeException;
+
+/**
+ * Prepare the website pages for deploy to GH Pages.
+ *
+ * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
+ *
+ * @internal
+ *
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.stringFound
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.intFound
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.stringFound
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.voidFound
+ * @phpcs:disable PHPCompatibility.InitialValue.NewConstantArraysUsingConst.Found
+ * @phpcs:disable PHPCompatibility.InitialValue.NewConstantScalarExpressions.constFound
+ */
+final class Website
+{
+
+    /**
+     * Path to project root (without trailing slash).
+     *
+     * @var string
+     */
+    const PROJECT_ROOT = __DIR__ . '/../..';
+
+    /**
+     * Relative path to target directory off project root (without trailing slash).
+     *
+     * @var string
+     */
+    const TARGET_DIR = '/deploy';
+
+    /**
+     * Files to copy.
+     *
+     * Source should be the relative path from the project root.
+     * Target should be the relative path in the target directory.
+     * If target is left empty, the target will be the same as the source.
+     *
+     * @var array<string => string target>
+     */
+    const FILES_TO_COPY = [
+        'README.md' => 'index.md',
+    ];
+
+    /**
+     * Frontmatter.
+     *
+     * @var string
+     */
+    const FRONTMATTER = '---
+---
+';
+
+    /**
+     * Resolved path to project root (with trailing slash).
+     *
+     * @var string
+     */
+    private $realRoot;
+
+    /**
+     * Resolved path to target directory (with trailing slash).
+     *
+     * @var string
+     */
+    private $realTarget;
+
+    /**
+     * Constructor
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        // Check if the target directory exists and if not, create it.
+        $targetDir = self::PROJECT_ROOT . self::TARGET_DIR;
+
+        if (@\is_dir($targetDir) === false) {
+            if (@\mkdir($targetDir, 0777, true) === false) {
+                throw new RuntimeException(\sprintf('Failed to create the %s directory.', $targetDir));
+            }
+        }
+
+        $realPath = \realpath($targetDir);
+        if ($realPath === false) {
+            throw new RuntimeException(\sprintf('Failed to find the %s directory.', $targetDir));
+        }
+
+        $this->realRoot   = \realpath(self::PROJECT_ROOT) . '/';
+        $this->realTarget = $realPath . '/';
+    }
+
+    /**
+     * Run the transformation.
+     *
+     * @return int Exit code.
+     */
+    public function run(): int
+    {
+        $exitcode = 0;
+
+        try {
+            $this->copyFiles();
+            $this->transformIndex();
+        } catch (RuntimeException $e) {
+            echo 'ERROR: ', $e->getMessage(), \PHP_EOL;
+            $exitcode = 1;
+        }
+
+        return $exitcode;
+    }
+
+    /**
+     * Copy files to the target directory.
+     *
+     * @return void
+     */
+    private function copyFiles(): void
+    {
+        foreach (self::FILES_TO_COPY as $source => $target) {
+            $source = $this->realRoot . $source;
+            if (empty($target)) {
+                $target = $this->realTarget . $source;
+            } else {
+                $target = $this->realTarget . $target;
+            }
+
+            // Bit round-about way of copying the files, but we need to make sure the target dir exists.
+            $contents = $this->getContents($source);
+            $this->putContents($target, $contents);
+        }
+    }
+
+    /**
+     * Transform the README to a usable homepage.
+     *
+     * - Remove the title and subtitle as those would become duplicate.
+     * - Remove most of the badges, except for the first three.
+     * - Transform those badges into HTML.
+     * - Add frontmatter.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException When any of the regexes do not yield any results.
+     */
+    private function transformIndex(): void
+    {
+        // Read the file.
+        $target   = $this->realTarget . '/index.md';
+        $contents = $this->getContents($target);
+
+        // Grab the start of the document.
+        $matched = \preg_match('`^(.+)\* \[Installation\]`s', $contents, $matches);
+        if ($matched !== 1) {
+            throw new RuntimeException('Failed to match start of document. Adjust the regex');
+        }
+
+        $startOfDoc = $matches[1];
+
+        // Grab the first few badges from the start of the document.
+        $matched = \preg_match(
+            '`((?:\[!\[[^\]]+\]\([^\)]+\)\]\([^\)]+\)[\n\r]+)+):construction:`',
+            $startOfDoc,
+            $matches
+        );
+        if ($matched !== 1) {
+            throw new RuntimeException('Failed to match badges. Adjust the regex');
+        }
+
+        $badges = \explode("\n", $matches[1]);
+        $badges = \array_filter($badges);
+        $badges = \array_map([$this, 'mdBadgeToHtml'], $badges);
+        $badges = \implode("\n    ", $badges);
+
+        $replacement = \sprintf(
+            '%s
+
+<div id="badges" aria-hidden="true">
+
+%s
+
+</div>
+
+',
+            self::FRONTMATTER,
+            '    ' . $badges
+        );
+
+        $contents = \str_replace($startOfDoc, $replacement, $contents);
+
+        $this->putContents($target, $contents);
+    }
+
+    /**
+     * Transform markdown badges into HTML badges.
+     *
+     * Jekyll runs into trouble doing this when we also want to keep the wrapper div with aria-hidden="true".
+     *
+     * @param string $mdBadge Markdown badge code.
+     *
+     * @return string
+     */
+    private function mdBadgeToHtml(string $mdBadge): string
+    {
+        $mdBadge = trim($mdBadge);
+
+        $matched = \preg_match(
+            '`^\[!\[(?<alt>[^\]]+)\]\((?<imgurl>[^\)]+)\)\]\((?<href>[^\)]+)\)$`',
+            $mdBadge,
+            $matches
+        );
+        if ($matched !== 1) {
+            throw new RuntimeException(\sprintf('Failed to parse the badge. Adjust the regex. Received: %s', $mdBadge));
+        }
+
+        return \sprintf(
+            '<a href="%s"><img src="%s" alt="%s" class="badge"></a>',
+            $matches['href'],
+            $matches['imgurl'],
+            $matches['alt']
+        );
+    }
+
+    /**
+     * Retrieve the contents of a file.
+     *
+     * @param string $source Path to the source file.
+     *
+     * @return string
+     *
+     * @throws \RuntimeException When the contents of the file could not be retrieved.
+     */
+    private function getContents(string $source): string
+    {
+        $contents = \file_get_contents($source);
+        if (!$contents) {
+            throw new RuntimeException(\sprintf('Failed to read doc file: %s', $source));
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Write a string to a file.
+     *
+     * @param string $target   Path to the target file.
+     * @param string $contents File contents to write.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException When the target directory could not be created.
+     * @throws \RuntimeException When the file could not be written to the target directory.
+     */
+    private function putContents(string $target, string $contents): void
+    {
+        // Check if the target directory exists and if not, create it.
+        $targetDir = \dirname($target);
+
+        if (@\is_dir($targetDir) === false) {
+            if (@\mkdir($targetDir, 0777, true) === false) {
+                throw new RuntimeException(\sprintf('Failed to create the %s directory.', $targetDir));
+            }
+        }
+
+        // Make sure the file always ends on a new line.
+        $contents = \rtrim($contents) . "\n";
+        if (\file_put_contents($target, $contents) === false) {
+            throw new RuntimeException(\sprintf('Failed to write to target location: %s', $target));
+        }
+    }
+}

--- a/.github/build/update-website.php
+++ b/.github/build/update-website.php
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * Website deploy preparation script.
+ *
+ * Grabs files which will be used in the website, adjusts if needed and places them in a target directory.
+ *
+ * {@internal This functionality has a minimum PHP requirement of PHP 7.2.}
+ *
+ * @internal
+ *
+ * @package   PHPCSDevTools\GHPages
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Build;
+
+require_once __DIR__ . '/Website.php';
+
+$websiteUpdater       = new Website();
+$websiteUpdateSuccess = $websiteUpdater->run();
+
+exit($websiteUpdateSuccess);

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -25,15 +25,12 @@ jobs:
       matrix:
         php: ['5.4', 'latest']
         phpcs_version: ['dev-master']
-        lint: [true]
 
         include:
           - php: '7.2'
             phpcs_version: '3.1.0'
-            lint: false
           - php: '5.4'
             phpcs_version: '3.1.0'
-            lint: false
 
     name: "QTest${{ matrix.lint && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -71,9 +68,13 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
 
-      - name: Lint against parse errors
-        if: ${{ matrix.lint }}
+      - name: Lint against parse errors (PHP 7.2+)
+        if: ${{ matrix.phpcs_version == 'dev-master' && matrix.php >= '7.2' }}
         run: composer lint
+
+      - name: Lint against parse errors (PHP < 7.2)
+        if: ${{ matrix.phpcs_version == 'dev-master' && matrix.php < '7.2' }}
+        run: composer lintlt72
 
       # Check that any sniffs available are feature complete.
       # This also acts as an integration test for the feature completeness script,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,9 +120,13 @@ jobs:
         with:
           composer-options: --ignore-platform-reqs
 
-      - name: Lint against parse errors
-        if: matrix.phpcs_version == 'dev-master'
+      - name: Lint against parse errors (PHP 7.2+)
+        if: ${{ matrix.phpcs_version == 'dev-master' && matrix.php >= '7.2' }}
         run: composer lint -- --checkstyle | cs2pr
+
+      - name: Lint against parse errors (PHP < 7.2)
+        if: ${{ matrix.phpcs_version == 'dev-master' && matrix.php < '7.2' }}
+        run: composer lintlt72 -- --checkstyle | cs2pr
 
       # Check that any sniffs available are feature complete.
       # This also acts as an integration test for the feature completeness script,

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,100 @@
+name: Build website
+
+on:
+  # Trigger the workflow whenever a new tag is created.
+  push:
+    branches:
+      - 'stable'
+  # And whenever this workflow or one of the associated scripts is updated (for a dry-run).
+  pull_request:
+    branches-ignore:
+      - 'stable'
+    paths:
+      - '.github/workflows/update-website.yml'
+      - '.github/build/**'
+  # Also allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: "Update website files"
+    # Don't run on forks.
+    if: github.repository == 'PHPCSStandards/PHPCSDevTools'
+
+    runs-on: ubuntu-latest
+    steps:
+      # By default use the `stable` branch as the published docs should always
+      # reflect the latest release.
+      # For testing changes to the workflow or the scripts, use the PR branch
+      # to have access to the latest version of the workflow/scripts.
+      - name: Determine branch to use
+        id: base_branch
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "::set-output name=BRANCH::$REF"
+          else
+            echo '::set-output name=BRANCH::stable'
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.base_branch.outputs.BRANCH }}
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
+          coverage: none
+
+      - name: Prepare the files which will be deployed to the GH Pages website
+        run: php .github/build/update-website.php
+
+      - name: "Set variable: short sha"
+        id: set_sha
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          shortsha=$(echo "$SHA" | cut -b 1-6)
+          echo "::set-output name=SHORTSHA::$shortsha"
+
+      - name: Prepare commit message
+        id: commit_msg
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'tag' ]]; then
+            echo "::set-output name=MSG::Update website for release of version $REF_NAME"
+          else
+            echo "::set-output name=MSG::Sync website after commit (sha: ${{ steps.set_sha.outputs.SHORTSHA }})"
+          fi
+
+      - name: Check GitHub Pages status
+        uses: crazy-max/ghaction-github-status@v2
+        with:
+          pages_threshold: major_outage
+
+      - name: Deploy the website
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          build_dir: 'deploy'
+          target_branch: 'gh-pages'
+          keep_history: true
+          #allow_empty_commit: false # Turn on after verification that it all works as expected.
+          jekyll: true
+          commit_message: ${{ steps.commit_msg.outputs.MSG }}
+          dry_run: ${{ steps.base_branch.outputs.BRANCH != 'stable' }}
+          verbose: ${{ matrix.verbose }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+deploy/
 vendor/
 composer.lock
 .phpcs.xml

--- a/README.md
+++ b/README.md
@@ -184,4 +184,4 @@ If unsure whether the changes you are proposing would be welcome, open an issue 
 
 License
 -------
-This code is released under the GNU Lesser General Public License (LGPLv3). For more information, visit http://www.gnu.org/copyleft/lesser.html
+This code is released under the [GNU Lesser General Public License (LGPLv3)](http://www.gnu.org/copyleft/lesser.html).

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
         ],
+        "lintlt72": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude .github/build"
+        ],
         "checkcs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],


### PR DESCRIPTION
This commit:
* Adds a new `update-website.yml` workflow which will automatically update the website whenever a commit is pushed to the `stable` branch.
    The script will also execute whenever changes are made to the workflow or the build scripts, but in that case, it will only do a _dry run_.
* This workflow will call the new `.github/build/update-website.php` script to prepare files to be updated on the website.
* ... which will in turn call the `.github/build/Website.php` class which does the actually preparing.

Initially, the build script will:
* Create a `deploy` directory to store files to be moved to the website.
* Copy the `README.md` file to `index.md`.
* Edit this file to:
    - Add frontmatter to indicate to Jekyll the file should be processed.
    - Remove the title and description as those would be duplicate.
    - Remove most of the badges.
    - For the remaining badges, turn them into HTML as Jekyll doesn't handle them correctly.

The build script has been set up using modern PHP and expects PHP 7.2 or higher to run (using PHP 8.1 in the workflow).

Includes:
* Adding a new `lintlt72` script to the `composer.json` file which will exclude the website build scripts from linting.
* Implementing use of the `lintlt72` script in the appropriate places in the `quicktest` and `test` workflows.
* Minor tweak to the `README` to ensure a URL will be hyperlinked.

Ref:
* [Action runner which handles moving the prepared files to the gh-pages branch](https://github.com/crazy-max/ghaction-github-pages)