### PR TITLE
GH Actions: various fixes

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -80,7 +80,7 @@ jobs:
       # This also acts as an integration test for the feature completeness script,
       # which is why it is run against various PHP versions and not in the "Sniff" stage.
       - name: Check for feature completeness
-        if: ${{ matrix.lint }}
+        if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer check-complete
 
       - name: Run the unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,50 +32,39 @@ jobs:
         # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2']
         phpcs_version: ['3.1.0', 'dev-master']
-        experimental: [false]
 
         include:
           # Complete the matrix, while preventing issues with PHPCS versions incompatible with certain PHP versions.
           - php: '8.1'
             phpcs_version: 'dev-master'
-            experimental: false
           - php: '8.1'
             phpcs_version: '3.6.1'
-            experimental: false
 
           - php: '8.0'
             phpcs_version: 'dev-master'
-            experimental: false
           - php: '8.0'
             phpcs_version: '3.5.7'
-            experimental: false
 
           - php: '7.4'
             phpcs_version: 'dev-master'
-            experimental: false
           - php: '7.4'
             phpcs_version: '3.5.0'
-            experimental: false
 
           - php: '7.3'
             phpcs_version: 'dev-master'
-            experimental: false
           - php: '7.3'
             phpcs_version: '3.3.1'
-            experimental: false
 
           # Experimental builds. These are allowed to fail.
           - php: '7.4'
             phpcs_version: '4.0.x-dev'
-            experimental: true
 
           - php: '8.2' # Nightly.
             phpcs_version: 'dev-master'
-            experimental: true
 
     name: "Test${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.php == '8.2' || matrix.phpcs_version == '4.0.x-dev' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### GH Actions: fix check complete not running in quick test

PR #73 removed the `lint` key from the quick test matrix, but this condition was not adjusted at the time, which meant that the feature complete integration test was not being run anymore in quick test.

### GH Actions: clean up/simplify the matrix

No need for the `experimental` key as we can just do a comparison in the `continue-on-error` directive.