### PR TITLE
GH Actions: version update for github status action runner

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -80,7 +80,7 @@ jobs:
           fi
 
       - name: Check GitHub Pages status
-        uses: crazy-max/ghaction-github-status@v2
+        uses: crazy-max/ghaction-github-status@v3
         with:
           pages_threshold: major_outage
 


### PR DESCRIPTION
This predefined action has had a major release.

This is mostly just a change of the Node version used by the action itself (from Node 12 to Node 16).

Refs:
* https://github.com/crazy-max/ghaction-github-status/releases/tag/v3.0.0