### PR TITLE
CheckSniffCompleteness::isComplete(): no double new line

### DIFF
--- a/Scripts/CheckSniffCompleteness.php
+++ b/Scripts/CheckSniffCompleteness.php
@@ -408,7 +408,7 @@ final class CheckSniffCompleteness
                 $feedback = "\033[32m{$feedback}\033[0m";
             }
 
-            echo \PHP_EOL, \PHP_EOL, $feedback, \PHP_EOL;
+            echo \PHP_EOL, $feedback, \PHP_EOL;
 
             return true;
         }


### PR DESCRIPTION
No need for a double new line above the "success" message.