### PR TITLE
GH Actions: version update for github pages action runner

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy the website
         if: success()
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v3
         with:
           build_dir: 'deploy'
           target_branch: 'gh-pages'


### PR DESCRIPTION
This predefined action has had a major release.

This is mostly just a change of the Node version used by the action itself (from Node 12 to Node 16).

Refs:
* https://github.com/crazy-max/ghaction-github-status/releases/tag/v3.0.0