### PR TITLE
Feature Complete: refactor

### DIFF
--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -8,14 +8,20 @@
  * @link      https://github.com/PHPCSStandards/PHPCSDevTools
  */
 
-namespace PHPCSDevTools\Scripts;
+namespace PHPCSDevTools\Scripts\FeatureComplete;
+
+use PHPCSDevTools\Scripts\FileList;
 
 /**
  * Check that each sniff is feature complete, i.e. has unit tests and documentation.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This class is not part of the public API. Backward compatibility is not guaranteed.
+ * ---------------------------------------------------------------------------------------------
+ *
  * @since 1.0.0
  */
-final class CheckSniffCompleteness
+final class Check
 {
 
     /**
@@ -451,7 +457,7 @@ final class CheckSniffCompleteness
     protected function showVersion()
     {
         echo 'PHPCSDevTools: Sniff feature completeness checker version ';
-        include __DIR__ . '/../VERSION';
+        include __DIR__ . '/../../VERSION';
         echo \PHP_EOL,
             'by Juliette Reinders Folmer', \PHP_EOL, \PHP_EOL;
     }

--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -143,7 +143,7 @@ final class Check
     /**
      * Validate the completeness of the sniffs in the repository.
      *
-     * @return void
+     * @return int Exit code.
      */
     public function validate()
     {
@@ -156,10 +156,10 @@ final class Check
         }
 
         if ($this->isComplete() !== true) {
-            exit(1);
+            return 1;
         }
 
-        exit(0);
+        return 0;
     }
 
     /**

--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -101,14 +101,7 @@ final class Check
     {
         $this->config = $config;
 
-        $sep = '/';
-        if (empty($this->config->targetDirs)) {
-            // If the user didn't provide a path, use the directory from which the script was run.
-            $this->targetDirs[] = $this->config->projectRoot;
-        } else {
-            // Handle Windows vs Unix file paths.
-            $sep = \DIRECTORY_SEPARATOR;
-        }
+        $sep = \DIRECTORY_SEPARATOR;
 
         // Handle excluded dirs.
         $exclude = '(?!\.git/)';

--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSDevTools\Scripts\FeatureComplete;
 
-use PHPCSDevTools\Scripts\FileList;
+use PHPCSDevTools\Scripts\Utils\FileList;
 
 /**
  * Check that each sniff is feature complete, i.e. has unit tests and documentation.

--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -147,7 +147,7 @@ final class Check
      */
     public function validate()
     {
-        $this->config->showVersion();
+        echo $this->config->getVersion();
 
         if ($this->config->verbose > 0) {
             echo 'Target dir(s):', \PHP_EOL,

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -91,6 +91,11 @@ final class Config
     public function __construct()
     {
         $this->processCliCommand();
+
+        if (empty($this->targetDirs)) {
+            // If the user didn't provide a path, use the directory from which the script was run.
+            $this->targetDirs[] = $this->projectRoot;
+        }
     }
 
     /**

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Scripts\FeatureComplete;
+
+use RuntimeException;
+
+/**
+ * Process command line arguments for the sniff completeness check.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is not part of the public API. Backward compatibility is not guaranteed.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @since 2.0.0
+ */
+final class Config
+{
+
+    /**
+     * The root directory of the project.
+     *
+     * @var string
+     */
+    private $projectRoot = '';
+
+    /**
+     * Whether to use "quiet" mode.
+     *
+     * This will silence all warnings, but still show the errors.
+     *
+     * To enable "quiet" mode, pass `-q` on the command line when calling
+     * the script.
+     *
+     * @var bool
+     */
+    private $quietMode = false;
+
+    /**
+     * Whether or not to show progress.
+     *
+     * To disable showing progress, pass `--no-progress` on the command line
+     * when calling the script.
+     *
+     * @var bool
+     */
+    private $showProgress = true;
+
+    /**
+     * Whether or not to show colored output.
+     *
+     * This will be automatically detected if not set from the command-line.
+     *
+     * @var bool
+     */
+    private $showColored;
+
+    /**
+     * Verbosity level.
+     *
+     * @var int
+     */
+    private $verbose = 0;
+
+    /**
+     * The target directories to examine.
+     *
+     * @var array
+     */
+    private $targetDirs = [];
+
+    /**
+     * Directories to exclude from the scan.
+     *
+     * @var array
+     */
+    private $excludedDirs = [
+        'vendor',
+    ];
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->processCliCommand();
+    }
+
+    /**
+     * Retrieve value of private properties.
+     *
+     * @param string $name Property name.
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        if (isset($this->$name)) {
+            return $this->$name;
+        }
+
+        return null;
+    }
+
+    /**
+     * Check whether a (private) property is set.
+     *
+     * @param string $name Property name.
+     *
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return isset($this->$name);
+    }
+
+    /**
+     * (Re-)Setting a property on this class is not allowed.
+     *
+     * - Prevent dynamic properties being set.
+     * - Prevent overruling the value of properties in this class.
+     *
+     * @param string $name  Property name.
+     * @param mixed  $value Property value.
+     *
+     * @return bool
+     */
+    public function __set($name, $value)
+    {
+        throw new RuntimeException(\sprintf('(Re-)Setting property $%s is not allowed', $name));
+    }
+
+    /**
+     * Unsetting a property on this class is not allowed.
+     *
+     * @param string $name Property name.
+     *
+     * @return bool
+     */
+    public function __unset($name)
+    {
+        throw new RuntimeException(\sprintf('Unsetting property $%s is not allowed', $name));
+    }
+
+    /**
+     * Process the received command arguments.
+     *
+     * @return void
+     */
+    protected function processCliCommand()
+    {
+        $args = $_SERVER['argv'];
+
+        // Remove the call to the script itself.
+        \array_shift($args);
+
+        $this->projectRoot = \getcwd();
+
+        if (empty($args)) {
+            // No options set.
+            $this->showColored = $this->isColorSupported();
+
+            return;
+        }
+
+        $argsFlipped = \array_flip($args);
+
+        if (isset($argsFlipped['-h'])
+            || isset($argsFlipped['--help'])
+        ) {
+            $this->showHelp();
+            exit(0);
+        }
+
+        if (isset($argsFlipped['-V'])
+            || isset($argsFlipped['--version'])
+        ) {
+            $this->showVersion();
+            exit(0);
+        }
+
+        if (isset($argsFlipped['-q'])
+            || isset($argsFlipped['--quiet'])
+        ) {
+            $this->quietMode = true;
+        }
+
+        if (isset($argsFlipped['--no-progress'])) {
+            $this->showProgress = false;
+        }
+
+        if (isset($argsFlipped['--no-colors'])) {
+            $this->showColored = false;
+        } elseif (isset($argsFlipped['--colors'])) {
+            $this->showColored = true;
+        } else {
+            $this->showColored = $this->isColorSupported();
+        }
+
+        if (isset($argsFlipped['-v'])) {
+            $this->verbose = 1;
+        }
+
+        foreach ($args as $arg) {
+            if (\strpos($arg, '--exclude=') === 0) {
+                $exclude = \substr($arg, 10);
+                if (empty($exclude)) {
+                    $this->excludedDirs = [];
+                    continue;
+                }
+
+                $exclude = \explode(',', $exclude);
+                $exclude = \array_map(
+                    static function ($subdir) {
+                        return \trim($subdir, '/');
+                    },
+                    $exclude
+                );
+
+                $this->excludedDirs = $exclude;
+                continue;
+            }
+
+            if ($arg[0] !== '-') {
+                // The user must have set a path to search. Let's ensure it is a valid path.
+                $realpath = \realpath($arg);
+
+                if ($realpath !== false) {
+                    $this->targetDirs[] = $realpath;
+                }
+            }
+        }
+    }
+
+    /**
+     * Detect whether or not the CLI supports colored output.
+     *
+     * @return bool
+     */
+    protected function isColorSupported()
+    {
+        // Windows.
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            if (\getenv('ANSICON') !== false || \getenv('ConEmuANSI') === 'ON') {
+                return true;
+            }
+
+            if (\function_exists('sapi_windows_vt100_support')) {
+                // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.sapi_windows_vt100_supportFound
+                return @\sapi_windows_vt100_support(\STDOUT);
+            }
+
+            return false;
+        }
+
+        // Linux/MacOS.
+        if (\function_exists('posix_isatty')) {
+            return @\posix_isatty(\STDOUT);
+        }
+
+        return false;
+    }
+
+    /**
+     * Display the version number of this script.
+     *
+     * @return void
+     */
+    public function showVersion()
+    {
+        echo 'PHPCSDevTools: Sniff feature completeness checker version ';
+        include __DIR__ . '/../../VERSION';
+        echo \PHP_EOL,
+            'by Juliette Reinders Folmer', \PHP_EOL, \PHP_EOL;
+    }
+
+    /**
+     * Display usage instructions.
+     *
+     * @return void
+     */
+    private function showHelp()
+    {
+        $this->showVersion();
+
+        echo 'Usage:', \PHP_EOL,
+            '    phpcs-check-feature-completeness', \PHP_EOL,
+            '    phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]', \PHP_EOL;
+
+        echo \PHP_EOL,
+            'Options:', \PHP_EOL,
+            '    directories   One or more specific directories to examine.', \PHP_EOL,
+            '                  Defaults to the directory from which the script is run.', \PHP_EOL,
+            '    -q, --quiet   Turn off warnings for missing documentation.', \PHP_EOL,
+            '    --exclude     Comma-delimited list of (relative) directories to exclude', \PHP_EOL,
+            '                  from the scan.', \PHP_EOL,
+            '                  Defaults to excluding the /vendor/ directory.', \PHP_EOL,
+            '    --no-progress Disable progress in console output.', \PHP_EOL,
+            '    --colors      Enable colors in console output.', \PHP_EOL,
+            '                  (disables auto detection of color support)', \PHP_EOL,
+            '    --no-colors   Disable colors in console output.', \PHP_EOL,
+            '    -v            Verbose mode.', \PHP_EOL,
+            '    -h, --help    Print this help.', \PHP_EOL,
+            '    -V, --version Display the current version of this script.', \PHP_EOL;
+    }
+}

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -86,13 +86,20 @@ final class Config
     ];
 
     /**
+     * Whether or not to execute the completeness check.
+     *
+     * @var bool
+     */
+    private $executeCheck = true;
+
+    /**
      * Constructor.
      */
     public function __construct()
     {
         $this->processCliCommand();
 
-        if (empty($this->targetDirs)) {
+        if ($this->executeCheck === true && empty($this->targetDirs)) {
             // If the user didn't provide a path, use the directory from which the script was run.
             $this->targetDirs[] = $this->projectRoot;
         }
@@ -181,14 +188,16 @@ final class Config
             || isset($argsFlipped['--help'])
         ) {
             $this->showHelp();
-            exit(0);
+            $this->executeCheck = false;
+            return;
         }
 
         if (isset($argsFlipped['-V'])
             || isset($argsFlipped['--version'])
         ) {
             $this->showVersion();
-            exit(0);
+            $this->executeCheck = false;
+            return;
         }
 
         if (isset($argsFlipped['-q'])

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -195,7 +195,7 @@ final class Config
         if (isset($argsFlipped['-V'])
             || isset($argsFlipped['--version'])
         ) {
-            $this->showVersion();
+            echo $this->getVersion();
             $this->executeCheck = false;
             return;
         }
@@ -283,16 +283,17 @@ final class Config
     }
 
     /**
-     * Display the version number of this script.
+     * Retrieve the version number of this script.
      *
-     * @return void
+     * @return string
      */
-    public function showVersion()
+    public function getVersion()
     {
-        echo 'PHPCSDevTools: Sniff feature completeness checker version ';
-        include __DIR__ . '/../../VERSION';
-        echo \PHP_EOL,
-            'by Juliette Reinders Folmer', \PHP_EOL, \PHP_EOL;
+        $text  = 'PHPCSDevTools: Sniff feature completeness checker version ';
+        $text .= \file_get_contents(__DIR__ . '/../../VERSION');
+        $text .= \PHP_EOL . 'by Juliette Reinders Folmer' . \PHP_EOL . \PHP_EOL;
+
+        return $text;
     }
 
     /**
@@ -302,7 +303,7 @@ final class Config
      */
     private function showHelp()
     {
-        $this->showVersion();
+        echo $this->getVersion();
 
         echo 'Usage:', \PHP_EOL,
             '    phpcs-check-feature-completeness', \PHP_EOL,

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -187,7 +187,8 @@ final class Config
         if (isset($argsFlipped['-h'])
             || isset($argsFlipped['--help'])
         ) {
-            $this->showHelp();
+            echo $this->getVersion();
+            echo $this->getHelp();
             $this->executeCheck = false;
             return;
         }
@@ -297,32 +298,32 @@ final class Config
     }
 
     /**
-     * Display usage instructions.
+     * Retrieve usage instructions.
      *
-     * @return void
+     * @return string
      */
-    private function showHelp()
+    private function getHelp()
     {
-        echo $this->getVersion();
+        $text  = 'Usage:' . \PHP_EOL;
+        $text .= '    phpcs-check-feature-completeness' . \PHP_EOL;
+        $text .= '    phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]' . \PHP_EOL;
 
-        echo 'Usage:', \PHP_EOL,
-            '    phpcs-check-feature-completeness', \PHP_EOL,
-            '    phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]', \PHP_EOL;
+        $text .= \PHP_EOL;
+        $text .= 'Options:' . \PHP_EOL;
+        $text .= '    directories   One or more specific directories to examine.' . \PHP_EOL;
+        $text .= '                  Defaults to the directory from which the script is run.' . \PHP_EOL;
+        $text .= '    -q, --quiet   Turn off warnings for missing documentation.' . \PHP_EOL;
+        $text .= '    --exclude     Comma-delimited list of (relative) directories to exclude' . \PHP_EOL;
+        $text .= '                  from the scan.' . \PHP_EOL;
+        $text .= '                  Defaults to excluding the /vendor/ directory.' . \PHP_EOL;
+        $text .= '    --no-progress Disable progress in console output.' . \PHP_EOL;
+        $text .= '    --colors      Enable colors in console output.' . \PHP_EOL;
+        $text .= '                  (disables auto detection of color support)' . \PHP_EOL;
+        $text .= '    --no-colors   Disable colors in console output.' . \PHP_EOL;
+        $text .= '    -v            Verbose mode.' . \PHP_EOL;
+        $text .= '    -h, --help    Print this help.' . \PHP_EOL;
+        $text .= '    -V, --version Display the current version of this script.' . \PHP_EOL;
 
-        echo \PHP_EOL,
-            'Options:', \PHP_EOL,
-            '    directories   One or more specific directories to examine.', \PHP_EOL,
-            '                  Defaults to the directory from which the script is run.', \PHP_EOL,
-            '    -q, --quiet   Turn off warnings for missing documentation.', \PHP_EOL,
-            '    --exclude     Comma-delimited list of (relative) directories to exclude', \PHP_EOL,
-            '                  from the scan.', \PHP_EOL,
-            '                  Defaults to excluding the /vendor/ directory.', \PHP_EOL,
-            '    --no-progress Disable progress in console output.', \PHP_EOL,
-            '    --colors      Enable colors in console output.', \PHP_EOL,
-            '                  (disables auto detection of color support)', \PHP_EOL,
-            '    --no-colors   Disable colors in console output.', \PHP_EOL,
-            '    -v            Verbose mode.', \PHP_EOL,
-            '    -h, --help    Print this help.', \PHP_EOL,
-            '    -V, --version Display the current version of this script.', \PHP_EOL;
+        return $text;
     }
 }

--- a/Scripts/Utils/FileList.php
+++ b/Scripts/Utils/FileList.php
@@ -8,7 +8,7 @@
  * @link      https://github.com/PHPCSStandards/PHPCSDevTools
  */
 
-namespace PHPCSDevTools\Scripts;
+namespace PHPCSDevTools\Scripts\Utils;
 
 use FilesystemIterator;
 use RecursiveDirectoryIterator;

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -37,8 +37,10 @@ if (is_file(__DIR__.'/../autoload.php') === true) {
 } else {
     // Presume git clone.
     require_once __DIR__ . '/../Scripts/Utils/FileList.php';
+    require_once __DIR__ . '/../Scripts/FeatureComplete/Config.php';
     require_once __DIR__ . '/../Scripts/FeatureComplete/Check.php';
 }
 
-$validate = new PHPCSDevTools\Scripts\FeatureComplete\Check();
+$config   = new PHPCSDevTools\Scripts\FeatureComplete\Config();
+$validate = new PHPCSDevTools\Scripts\FeatureComplete\Check($config);
 $validate->validate();

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -41,6 +41,11 @@ if (is_file(__DIR__.'/../autoload.php') === true) {
     require_once __DIR__ . '/../Scripts/FeatureComplete/Check.php';
 }
 
-$config   = new PHPCSDevTools\Scripts\FeatureComplete\Config();
+$config = new PHPCSDevTools\Scripts\FeatureComplete\Config();
+if ($config->executeCheck === false) {
+    // This was a help request or version check.
+    exit(0);
+}
+
 $validate = new PHPCSDevTools\Scripts\FeatureComplete\Check($config);
 $validate->validate();

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -48,4 +48,4 @@ if ($config->executeCheck === false) {
 }
 
 $validate = new PHPCSDevTools\Scripts\FeatureComplete\Check($config);
-$validate->validate();
+exit($validate->validate());

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -36,7 +36,7 @@ if (is_file(__DIR__.'/../autoload.php') === true) {
     require_once __DIR__.'/../autoload.php';
 } else {
     // Presume git clone.
-    require_once __DIR__ . '/../Scripts/FileList.php';
+    require_once __DIR__ . '/../Scripts/Utils/FileList.php';
     require_once __DIR__ . '/../Scripts/FeatureComplete/Check.php';
 }
 

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -37,8 +37,8 @@ if (is_file(__DIR__.'/../autoload.php') === true) {
 } else {
     // Presume git clone.
     require_once __DIR__ . '/../Scripts/FileList.php';
-    require_once __DIR__ . '/../Scripts/CheckSniffCompleteness.php';
+    require_once __DIR__ . '/../Scripts/FeatureComplete/Check.php';
 }
 
-$validate = new PHPCSDevTools\Scripts\CheckSniffCompleteness();
+$validate = new PHPCSDevTools\Scripts\FeatureComplete\Check();
 $validate->validate();


### PR DESCRIPTION
This is a preliminary commit to improve the maintainability and testability of the Feature Complete code.

It is marked as a breaking change as classes/methods are being renamed and moved around. However, the "break" only applies to codebases _building onto_ this feature, not for use of this feature from the typical `vendor/bin/phpcs-check-feature-completeness` entrypoint.

The renamed/moved classes have now also been explicitly marked as internal and not part of the external API to allow for these type of changes in the future without causing the need for a major release.

## Commit details

### CheckSniffCompleteness: move class to subdirectory

### Move FileList class to Utils directory

### FeatureComplete/Check: split parsing of configuration off to separate class

Changes in the functionality now contained in the `Config` class:
* All properties are now `private`.
* A magic `__get()` and `__isset()` method is available to access the value of the properties.
* A magic `__set()` and `__unset()` method have been added to _prevent_ any changes to the value of the properties from outside the class and prevent dynamic properties from being set.
* The `showVersion()` method is now `public` as it needs to be called from the `Check` class.
* The `showHelp()` method is now `private`.

Includes:
* Re-ordering the properties.

### FeatureComplete/Check/Config: move setting of missing target dir to Config

... as the way things are set up now, the config cannot be changed from outside the class and it makes sense to always have a target dir set.

### FeatureComplete/Config: add property toggle to execute the check

Instead of a hard `exit()` from within the `Config` script, let the controller exit based on the value of the `$executeCheck` property.

This improves the testability of the class.

### FeatureComplete/Check: return exit code instead of exiting

Instead of a hard `exit()` from within the `Check` script, let the controller exit with the returned exit code.

This improves the testability of the class.

### FeatureComplete/Config::showVersion(): refactor to getVersion()

... to improve testability of the code.

### FeatureComplete/Config::showHelp(): refactor to getHelp()

... to improve testability of the code.