### PR TITLE
Feature Complete: add tests for the `Config` class

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 /phpunit.xml.dist      export-ignore
 /phpunit-bootstrap.php export-ignore
 /PHPCSDebug/Tests      export-ignore
+/Tests                 export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -83,5 +83,9 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer check-complete
 
-      - name: Run the unit tests
-        run: composer run-tests
+      - name: Run the unit tests for the PHPCSDebug sniff
+        run: composer test-sniff
+
+      - name: Run the unit tests for the DevTools
+        if: ${{ matrix.phpcs_version == 'dev-master' }}
+        run: composer test-tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,5 +124,9 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer check-complete
 
-      - name: Run the unit tests
-        run: composer run-tests
+      - name: Run the unit tests for the PHPCSDebug sniff
+        run: composer test-sniff
+
+      - name: Run the unit tests for the DevTools
+        if: ${{ matrix.phpcs_version == 'dev-master' }}
+        run: composer test-tools

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -257,6 +257,8 @@ final class Config
     /**
      * Detect whether or not the CLI supports colored output.
      *
+     * @codeCoverageIgnore
+     *
      * @return bool
      */
     protected function isColorSupported()

--- a/Tests/FeatureComplete/Config/GetHelpTest.php
+++ b/Tests/FeatureComplete/Config/GetHelpTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Tests\FeatureComplete\Config;
+
+use PHPCSDevTools\Scripts\FeatureComplete\Config;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the "show help" feature.
+ *
+ * @covers \PHPCSDevTools\Scripts\FeatureComplete\Config::getHelp
+ */
+final class GetHelpTest extends TestCase
+{
+
+    /**
+     * Expected help text output.
+     *
+     * @var string
+     */
+    private $expectedOutput = '
+Usage:
+    phpcs-check-feature-completeness
+    phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]
+
+Options:
+    directories   One or more specific directories to examine.
+                  Defaults to the directory from which the script is run.
+    -q, --quiet   Turn off warnings for missing documentation.
+    --exclude     Comma-delimited list of (relative) directories to exclude
+                  from the scan.
+                  Defaults to excluding the /vendor/ directory.
+    --no-progress Disable progress in console output.
+    --colors      Enable colors in console output.
+                  (disables auto detection of color support)
+    --no-colors   Disable colors in console output.
+    -v            Verbose mode.
+    -h, --help    Print this help.
+    -V, --version Display the current version of this script.';
+
+    /**
+     * Verify the "show help" command generates the expected output.
+     *
+     * @dataProvider dataShowHelp
+     *
+     * @param string $command The command as received from the command line.
+     *
+     * @return void
+     */
+    public function testShowHelp($command)
+    {
+        $regex = '`' .  \preg_quote($this->expectedOutput, '`') . '`';
+        // Make the regex ignore differences in line endings.
+        $regex = \preg_replace('`[\r\n]+`', '[\r\n]+', $regex);
+        $this->expectOutputRegex($regex);
+
+        $_SERVER['argv'] = \explode(' ', $command);
+        new Config();
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataShowHelp()
+    {
+        return [
+            '-h'     => [
+                'command' => 'phpcs-check-feature-completeness -h',
+            ],
+            '--help' => [
+                'command' => './phpcs-check-feature-completeness --help',
+            ],
+        ];
+    }
+}

--- a/Tests/FeatureComplete/Config/GetVersionTest.php
+++ b/Tests/FeatureComplete/Config/GetVersionTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Tests\FeatureComplete\Config;
+
+use PHPCSDevTools\Scripts\FeatureComplete\Config;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the "show version" feature.
+ *
+ * @covers \PHPCSDevTools\Scripts\FeatureComplete\Config::getVersion
+ */
+final class GetVersionTest extends TestCase
+{
+
+    /**
+     * Verify the "show version" command generates the expected output.
+     *
+     * @dataProvider dataShowVersion
+     *
+     * @param string $command The command as received from the command line.
+     *
+     * @return void
+     */
+    public function testShowVersion($command)
+    {
+        $regex = '`^PHPCSDevTools: Sniff feature completeness checker version'
+            . ' [0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}(?:-(?:alpha|beta|RC)\S+)?'
+            . '[\r\n]+by Juliette Reinders Folmer[\r\n]*$`';
+        $this->expectOutputRegex($regex);
+
+        $_SERVER['argv'] = \explode(' ', $command);
+        new Config();
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataShowVersion()
+    {
+        return [
+            '-V'        => [
+                'command' => 'command -V',
+            ],
+            '--version' => [
+                'command' => 'phpcs-check-feature-completeness --version',
+            ],
+        ];
+    }
+}

--- a/Tests/FeatureComplete/Config/MagicMethodsTest.php
+++ b/Tests/FeatureComplete/Config/MagicMethodsTest.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Tests\FeatureComplete\Config;
+
+use PHPCSDevTools\Scripts\FeatureComplete\Config;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
+
+/**
+ * Test the magic methods in the Config class.
+ *
+ * @phpcs:disable Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned -- If needed, fix once replaced by better sniff.
+ */
+final class MagicMethodsTest extends XTestCase
+{
+
+    /**
+     * Class under test.
+     *
+     * @var \PHPCSDevTools\Scripts\FeatureComplete\Config
+     */
+    private $config;
+
+    /**
+     * Create the class under test.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function setUpClass()
+    {
+        parent::setUp();
+        $this->config = new Config();
+    }
+
+    /**
+     * Test magic __get().
+     *
+     * @dataProvider dataGet
+     * @covers       \PHPCSDevTools\Scripts\FeatureComplete\Config::__get
+     *
+     * @param string $propertyName The name of the property to retrieve.
+     * @param mixed  $expected     The expected value for the property.
+     *
+     * @return void
+     */
+    public function testGet($propertyName, $expected)
+    {
+        $this->assertSame($expected, $this->config->$propertyName);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return void
+     */
+    public function dataGet()
+    {
+        return [
+            'property which doesn\'t exist on the class' => [
+                'propertyName' => 'doesnotexist',
+                'expected'     => null,
+            ],
+            'property which exists on the class and access is allowed' => [
+                'propertyName' => 'verbose',
+                'expected'     => 0,
+            ],
+            'property which exists on the class and access is not allowed' => [
+                'propertyName' => 'helpTexts',
+                'expected'     => null,
+            ],
+        ];
+    }
+
+    /**
+     * Test magic __isset().
+     *
+     * @dataProvider dataIsset
+     * @covers       \PHPCSDevTools\Scripts\FeatureComplete\Config::__isset
+     *
+     * @param string $propertyName The name of the property to retrieve.
+     * @param mixed  $expected     Whether the property is expected to report as set or not set.
+     *
+     * @return void
+     */
+    public function testIsset($propertyName, $expected)
+    {
+        $this->assertSame($expected, isset($this->config->$propertyName));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return void
+     */
+    public function dataIsset()
+    {
+        return [
+            'property which doesn\'t exist on the class' => [
+                'propertyName' => 'doesnotexist',
+                'expected'     => false,
+            ],
+            'property which exists on the class and access is allowed' => [
+                'propertyName' => 'verbose',
+                'expected'     => true,
+            ],
+            'property which exists on the class and access is not allowed' => [
+                'propertyName' => 'helpTexts',
+                'expected'     => false,
+            ],
+        ];
+    }
+
+    /**
+     * Verify that properties cannot be overloaded and dynamic properties are not allowed.
+     *
+     * @dataProvider dataSetUnset
+     * @covers       \PHPCSDevTools\Scripts\FeatureComplete\Config::__set
+     *
+     * @param string $propertyName The name of the property.
+     *
+     * @return void
+     */
+    public function testSet($propertyName)
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage("(Re-)Setting property \${$propertyName} is not allowed");
+
+        $this->config->$propertyName = 'testing 1 2 3';
+    }
+
+    /**
+     * Verify that properties cannot be unset.
+     *
+     * @dataProvider dataSetUnset
+     * @covers       \PHPCSDevTools\Scripts\FeatureComplete\Config::__unset
+     *
+     * @param string $propertyName The name of the property.
+     *
+     * @return void
+     */
+    public function testUnset($propertyName)
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage("Unsetting property \${$propertyName} is not allowed");
+
+        unset($this->config->$propertyName);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return void
+     */
+    public function dataSetUnset()
+    {
+        return [
+            'property which doesn\'t exist on the class' => ['doesnotexist'],
+            'property which exists on the class'         => ['verbose'],
+        ];
+    }
+}

--- a/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
+++ b/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Tests\FeatureComplete\Config;
+
+use PHPCSDevTools\Scripts\FeatureComplete\Config;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the parsing of command line arguments.
+ *
+ * @covers \PHPCSDevTools\Scripts\FeatureComplete\Config::__construct
+ * @covers \PHPCSDevTools\Scripts\FeatureComplete\Config::processCliCommand
+ *
+ * @phpcs:disable Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned -- If needed, fix once replaced by better sniff.
+ */
+final class ProcessCliCommandTest extends TestCase
+{
+
+    /**
+     * Relevant properties in the Config class and their default value.
+     *
+     * @var array
+     */
+    private $defaultSettings = [
+        'projectRoot'  => '',
+        'quietMode'    => false,
+        'showProgress' => true,
+        'showColored'  => null,
+        'verbose'      => 0,
+        'targetDirs'   => [],
+        'excludedDirs' => [
+            'vendor',
+        ],
+        'executeCheck' => true,
+    ];
+
+    /**
+     * Verify that unsupported arguments are ignored without notice and don't affect the supported arguments.
+     *
+     * @dataProvider dataProcessCliCommandUnsupportedArgument
+     *
+     * @param string $command The command as received from the command line.
+     *
+     * @return void
+     */
+    public function testProcessCliCommandUnsupportedArgument($command)
+    {
+        $expected                = $this->defaultSettings;
+        $expected['projectRoot'] = \getcwd();
+        $expected['targetDirs']  = [$expected['projectRoot']];
+
+        $_SERVER['argv'] = \explode(' ', $command);
+        $config          = new Config();
+        $actual          = $this->getCurrentValues($config);
+
+        unset($expected['showColored'], $actual['showColored']);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataProcessCliCommandUnsupportedArgument()
+    {
+        return [
+            'Unsupported short arguments' => [
+                'command' => './phpcs-check-feature-completeness -a -e',
+            ],
+            'Unsupported long arguments' => [
+                'command' => 'phpcs-check-feature-completeness --show-progress --unsupported-arg',
+            ],
+            'Unsupported long argument using an = sign' => [
+                'command' => 'aliased-command --ignore=vendor',
+            ],
+        ];
+    }
+
+    /**
+     * Test parsing the arguments received from the command line.
+     *
+     * @dataProvider dataProcessCliCommand
+     *
+     * @param string $command          The command as received from the command line.
+     * @param array  $expectedChanged  The Config class properties which are expected to have been
+     *                                 changed (key) with their value.
+     * @param bool   $checkShowColored Whether to check the value of the "showColored" setting.
+     *                                 This setting should only be checked when `--color` or
+     *                                 `--no-color` has been explicitly passed in the $command
+     *                                 as the auto-detection is not testable.
+     *                                 Defaults to `false`.
+     *
+     * @return void
+     */
+    public function testProcessCliCommand($command, array $expectedChanged, $checkShowColored = false)
+    {
+        $expected = \array_merge($this->defaultSettings, $expectedChanged);
+
+        $_SERVER['argv'] = \explode(' ', $command);
+        $config          = new Config();
+        $actual          = $this->getCurrentValues($config);
+
+        if ($checkShowColored === false) {
+            unset($expected['showColored'], $actual['showColored']);
+
+            // Just make sure the value is set and is a boolean.
+            $this->assertTrue(\is_bool($config->showColored), 'The "showColored" property is not a boolean');
+        }
+
+        $this->assertSame($expected, $actual, 'Parsing the command line did not set the properties correctly');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataProcessCliCommand()
+    {
+        /*
+         * For project root, we only really verify that it has been set as the value will depend
+         * on the environment in which the tests are being run.
+         */
+        $projectRoot = \getcwd();
+
+        return [
+            'No arguments at all - verify target dir will be set to project root' => [
+                'command'         => './phpcs-check-feature-completeness',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'targetDirs'  => [
+                        $projectRoot,
+                    ],
+                ],
+            ],
+            'No arguments other than a path' => [
+                'command'         => './phpcs-check-feature-completeness .',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'targetDirs'  => [
+                        \realpath('.'),
+                    ],
+                ],
+            ],
+            'No arguments other than multiple valid paths in varying formats' => [
+                'command'         => './phpcs-check-feature-completeness ./PHPCSDebug ./Tests bin ' . __DIR__ . '/../../../.github/',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'targetDirs'  => [
+                        \realpath('./PHPCSDebug'),
+                        \realpath('./Tests'),
+                        \realpath('bin'),
+                        \realpath(__DIR__ . '/../../../.github/'),
+                    ],
+                ],
+            ],
+            'No arguments other than multiple paths - verify that invalid paths will be filtered out' => [
+                'command'         => './phpcs-check-feature-completeness ./src /Tests bin ' . __DIR__ . '/../absolute/',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'targetDirs'  => [
+                        \realpath('bin'),
+                    ],
+                ],
+            ],
+            'Multiple short arguments: -q -v' => [
+                'command'         => 'phpcs-check-feature-completeness -q -v .',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'quietMode'   => true,
+                    'verbose'     => 1,
+                    'targetDirs'  => [
+                        \realpath('.'),
+                    ],
+                ],
+            ],
+            'Multiple long arguments, no target dir' => [
+                'command'          => './phpcs-check-feature-completeness --exclude=node_modules --no-progress --colors',
+                'expectedChanged'  => [
+                    'projectRoot'  => $projectRoot,
+                    'showProgress' => false,
+                    'showColored'  => true,
+                    'targetDirs'   => [
+                        $projectRoot,
+                    ],
+                    'excludedDirs' => [
+                        'node_modules',
+                    ],
+                ],
+                'checkShowColored' => true,
+            ],
+            'Multiple excludes, varying formats, including subdir and invalid paths' => [
+                'command'         => './phpcs-check-feature-completeness .'
+                    . ' --exclude=.git,./.github/,Tests/FeatureComplete,/node_modules/,tests/notvalid,../../levelup',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'targetDirs'   => [
+                        \realpath('.'),
+                    ],
+                    'excludedDirs' => [
+                        '.git',
+                        './.github',
+                        'Tests/FeatureComplete',
+                        'node_modules',
+                        'tests/notvalid',
+                        '../../levelup',
+                    ],
+                ],
+            ],
+            'Exclude, no value' => [
+                'command'         => './phpcs-check-feature-completeness --exclude=',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'targetDirs'   => [
+                        $projectRoot,
+                    ],
+                    'excludedDirs' => [],
+                ],
+            ],
+            'Quiet mode (short arg)' => [
+                'command'         => './phpcs-check-feature-completeness -q',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'quietMode'   => true,
+                    'targetDirs'  => [
+                        $projectRoot,
+                    ],
+                ],
+            ],
+            'Quiet mode (long arg)' => [
+                'command'         => 'aliased-command --quiet',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'quietMode'   => true,
+                    'targetDirs'  => [
+                        $projectRoot,
+                    ],
+                ],
+            ],
+            'No progress' => [
+                'command'         => 'phpcs-check-feature-completeness . --no-progress',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'showProgress' => false,
+                    'targetDirs'   => [
+                        \realpath('.'),
+                    ],
+                ],
+            ],
+            'Force enable colors' => [
+                'command'          => 'phpcs-check-feature-completeness . --colors',
+                'expectedChanged'  => [
+                    'projectRoot' => $projectRoot,
+                    'showColored' => true,
+                    'targetDirs'  => [
+                        \realpath('.'),
+                    ],
+                ],
+                'checkShowColored' => true,
+            ],
+            'Force disable colors' => [
+                'command'          => 'phpcs-check-feature-completeness . --no-colors',
+                'expectedChanged'  => [
+                    'projectRoot' => $projectRoot,
+                    'showColored' => false,
+                    'targetDirs'  => [
+                        \realpath('.'),
+                    ],
+                ],
+                'checkShowColored' => true,
+            ],
+            'Verbose mode' => [
+                'command'         => 'phpcs-check-feature-completeness . -v',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'verbose'     => 1,
+                    'targetDirs'  => [
+                        \realpath('.'),
+                    ],
+                ],
+            ],
+            'All together now' => [
+                'command'          => 'phpcs-check-feature-completeness src -q --exclude=ignoreme,/other,./tests/'
+                    . ' PHPCSDebug --no-progress ./Tests --colors -v .',
+                'expectedChanged'  => [
+                    'projectRoot'  => $projectRoot,
+                    'quietMode'    => true,
+                    'showProgress' => false,
+                    'showColored'  => true,
+                    'verbose'      => 1,
+                    'targetDirs'   => [
+                        \realpath('PHPCSDebug'),
+                        \realpath('./Tests'),
+                        \realpath('.'),
+                    ],
+                    'excludedDirs' => [
+                        'ignoreme',
+                        'other',
+                        './tests',
+                    ],
+                ],
+                'checkShowColored' => true,
+            ],
+        ];
+    }
+
+    /**
+     * Verify how CLI arguments which generate output are handled.
+     *
+     * These tests also verify that all other passed arguments are ignored.
+     *
+     * The actual output generated is tested separately in other test classes.
+     *
+     * @dataProvider dataProcessCliCommandOutputOnlyArgs
+     *
+     * @param string $command         The command as received from the command line.
+     * @param array  $expectedChanged The Config class properties which are expected to have been
+     *                                changed (key) with their value.
+     *
+     * @return void
+     */
+    public function testProcessCliCommandOutputOnlyArgs($command, $expectedChanged)
+    {
+        $this->expectOutputRegex('`.*`s');
+        $expected = \array_merge($this->defaultSettings, $expectedChanged);
+
+        $_SERVER['argv'] = \explode(' ', $command);
+        $config          = new Config();
+        $actual          = $this->getCurrentValues($config);
+
+        unset($expected['showColored'], $actual['showColored']);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataProcessCliCommandOutputOnlyArgs()
+    {
+        /*
+         * For project root, we only verify that it has been set as the value will depend on the
+         * environment in which the tests are being run.
+         */
+        $projectRoot = \getcwd();
+
+        return [
+            'Help (short arg)' => [
+                'command'         => 'phpcs-check-feature-completeness -h . --no-progress --colors',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'executeCheck' => false,
+                ],
+            ],
+            'Help (long arg)' => [
+                'command'         => 'phpcs-check-feature-completeness --help -q --exclude=src',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'executeCheck' => false,
+                ],
+            ],
+            'Version (short arg)' => [
+                'command'         => 'phpcs-check-feature-completeness -V --no-colors src tests',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'executeCheck' => false,
+                ],
+            ],
+            'Version (long arg)' => [
+                'command'         => 'phpcs-check-feature-completeness --version -v -q',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'executeCheck' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Helper method: retrieve the current values of the Config properties as an array.
+     *
+     * @param \PHPCSDevTools\Scripts\FeatureComplete\Config $config Config object
+     *
+     * @return array
+     */
+    private function getCurrentValues(Config $config)
+    {
+        $current = [];
+        foreach ($this->defaultSettings as $name => $value) {
+            $current[$name] = $config->$name;
+        }
+
+        return $current;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,21 @@
     },
     "require-dev" : {
         "roave/security-advisories" : "dev-master",
-        "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit" : "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0.0",
         "phpcsstandards/phpcsdevcs": "^1.1.3",
-        "phpcsstandards/phpcsutils" : "^1.0"
+        "phpcsstandards/phpcsutils" : "^1.0",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "autoload-dev" : {
+        "psr-4": {
+            "PHPCSDevTools\\Tests\\": "Tests/"
         }
     },
     "bin": [
@@ -56,8 +62,14 @@
         "fixcs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
         ],
-        "run-tests": [
+        "test": [
             "@php ./vendor/phpunit/phpunit/phpunit"
+        ],
+        "test-sniff": [
+            "@php ./vendor/phpunit/phpunit/phpunit --testsuite DebugSniff"
+        ],
+        "test-tools": [
+            "@php ./vendor/phpunit/phpunit/phpunit --testsuite DevTools"
         ],
         "check-complete": [
             "@php ./bin/phpcs-check-feature-completeness ./PHPCSDebug"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -56,4 +56,8 @@
         <exclude-pattern>/phpunit-bootstrap\.php$</exclude-pattern>
     </rule>
 
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>/Tests/*\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -87,5 +87,13 @@ pointing to the PHPCSUtils directory.
     die(1);
 }
 
+// Load test related autoloader.
+require_once __DIR__ . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+
+// Load the scripts for the Feature Complete tooling.
+require_once __DIR__ . '/Scripts/Utils/FileList.php';
+require_once __DIR__ . '/Scripts/FeatureComplete/Config.php';
+require_once __DIR__ . '/Scripts/FeatureComplete/Check.php';
+
 // Clean up.
 unset($ds, $phpcsDir, $phpcsUtilsDir, $vendorDir);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,8 +13,11 @@
     forceCoversAnnotation="true">
 
     <testsuites>
-        <testsuite name="PHPCSDevTools">
+        <testsuite name="DebugSniff">
             <directory suffix="UnitTest.php">./PHPCSDebug/Tests/</directory>
+        </testsuite>
+        <testsuite name="DevTools">
+            <directory suffix="Test.php">./Tests/FeatureComplete/</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
### Feature Complete: prepare for adding tests for this tool

**PHPUnit config**
* Add a second test suite for the "Feature Complete" tooling tests and other future non-PHPCS dependent tests.

**Composer**
* Tweak the supported PHPUnit version to ensure the namespaced `TestCase` class is always available.
* Add the PHPUnit Polyfills for use by those tests which need to use expectations/assertions which have changed over time.
* Add autoloading for test files.
* Add separate scripts to run the different test suites.
* Rename the `run-tests` script (to run all tests) to `test` to be in line with the names of similar scripts in other repos in this organisation.

**PHPUnit bootstrap**
* Load the autoloader for the PHPUnit Polyfills.
* Load the scripts involved in the "Feature Complete" tooling via `require`s.
    Note: the test bootstrap does not use the Composer `autoload.php` file for two reasons:
    1. For the sniff tests, we want to make sure that the sniff plays nice with the PHPCS native autoloader.
    2. The actual "runner" for the Feature Complete tool doesn't use Composer autoload either.
    3. The scripts aren't actually indexed via Composer.

**GH Actions workflow**
* Adjust the existing test run to run only the sniff test testsuite.
* Add a second test run to run the tooling test suite which is only run once per PHP version.

**.gitattributes**
* Ignore the `Tests` directory for distribution archives.

**PHPCS config**
* Ignore long lines in test files as the "commands" to be passed can sometimes be quite long.

### FeatureComplete/Config: add tests verifying correct parsing of CLI arguments

### FeatureComplete/Config: add tests verifying the functionality of the magic methods

### FeatureComplete/Config: add test verifying the "show version" command output

### FeatureComplete/Config: add test verifying the "show help" command output

### FeatureComplete/Config: mark isColorSupported() method as untestable

.... as the result is too dependent on the system on which the function is being run, so this cannot be simulated via tests.