### PR TITLE
FeatureComplete/Config: add tolerance for quoted values for the "exclude" option

### DIFF
--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -231,6 +231,7 @@ final class Config
                     continue;
                 }
 
+                $exclude = \trim($exclude, '"\''); // Strip potential quotes.
                 $exclude = \explode(',', $exclude);
                 $exclude = \array_map(
                     static function ($subdir) {

--- a/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
+++ b/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
@@ -217,6 +217,20 @@ final class ProcessCliCommandTest extends TestCase
                     ],
                 ],
             ],
+            'Exclude, complete value wrapped in quotes' => [
+                'command'         => './phpcs-check-feature-completeness --exclude=".git,./.github/,Tests/FeatureComplete"',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'targetDirs'   => [
+                        $projectRoot,
+                    ],
+                    'excludedDirs' => [
+                        '.git',
+                        './.github',
+                        'Tests/FeatureComplete',
+                    ],
+                ],
+            ],
             'Exclude, no value' => [
                 'command'         => './phpcs-check-feature-completeness --exclude=',
                 'expectedChanged' => [


### PR DESCRIPTION
This improves compatibility for exclude paths containing spaces.

Includes unit test.