### PR TITLE
FeatureComplete/Config: add tolerance for extra whitespace in the command

### DIFF
--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -243,7 +243,7 @@ final class Config
                 continue;
             }
 
-            if ($arg[0] !== '-') {
+            if (isset($arg[0]) && $arg[0] !== '-') {
                 // The user must have set a path to search. Let's ensure it is a valid path.
                 $realpath = \realpath($arg);
 

--- a/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
+++ b/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
@@ -143,6 +143,15 @@ final class ProcessCliCommandTest extends TestCase
                     ],
                 ],
             ],
+            'No arguments at all and trailing whitespace in the command' => [
+                'command'         => './phpcs-check-feature-completeness    ',
+                'expectedChanged' => [
+                    'projectRoot' => $projectRoot,
+                    'targetDirs'  => [
+                        $projectRoot,
+                    ],
+                ],
+            ],
             'No arguments other than a path' => [
                 'command'         => './phpcs-check-feature-completeness .',
                 'expectedChanged' => [
@@ -289,9 +298,9 @@ final class ProcessCliCommandTest extends TestCase
                     ],
                 ],
             ],
-            'All together now' => [
-                'command'          => 'phpcs-check-feature-completeness src -q --exclude=ignoreme,/other,./tests/'
-                    . ' PHPCSDebug --no-progress ./Tests --colors -v .',
+            'All together now, includes testing for handling of additional whitespace between arguments' => [
+                'command'          => 'phpcs-check-feature-completeness src    -q --exclude=ignoreme,/other,./tests/'
+                    . ' PHPCSDebug   --no-progress    ./Tests   --colors -v .',
                 'expectedChanged'  => [
                     'projectRoot'  => $projectRoot,
                     'quietMode'    => true,


### PR DESCRIPTION
Without this fix, the script would throw a "Uninitialized string offset 0" warning when the command contained superfluous/trailing whitespace.

Includes unit tests.