### PR TITLE
Feature Complete/Config: improve help texts and colorize help

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,19 @@ phpcs-check-feature-completeness ./StandardName
 
 #### Options
 ```
-directories   One or more specific directories to examine.
-              Defaults to the directory from which the script is run.
--q, --quiet   Turn off warnings for missing documentation.
---exclude     Comma-delimited list of (relative) directories to exclude
-              from the scan.
-              Defaults to excluding the /vendor/ directory.
---no-progress Disable progress in console output.
---colors      Enable colors in console output.
-              (disables auto detection of color support)
---no-colors   Disable colors in console output.
--v            Verbose mode.
--h, --help    Print this help.
--V, --version Display the current version of this script.
+directories <dir>     One or more specific directories to examine.
+                      Defaults to the directory from which the script is run.
+-q, --quiet           Turn off warnings for missing documentation.
+--exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
+                      exclude from the scan.
+                      Defaults to excluding the /vendor/ directory.
+--no-progress         Disable progress in console output.
+--colors              Enable colors in console output.
+                      (disables auto detection of color support)
+--no-colors           Disable colors in console output.
+-v                    Verbose mode.
+-h, --help            Print this help.
+-V, --version         Display the current version of this script.
 ```
 
 

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -25,6 +25,20 @@ final class Config
 {
 
     /**
+     * Max width for help text.
+     *
+     * @var int
+     */
+    const MAX_WIDTH = 80;
+
+    /**
+     * Margin for help options.
+     *
+     * @var string
+     */
+    const LEFT_MARGIN = '  ';
+
+    /**
      * The root directory of the project.
      *
      * @var string
@@ -93,6 +107,58 @@ final class Config
     private $executeCheck = true;
 
     /**
+     * Help texts.
+     *
+     * @var array
+     */
+    private $helpTexts = [
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        'Usage'   => [
+            ['text' => 'phpcs-check-feature-completeness'],
+            ['text' => 'phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]'],
+        ],
+        'Options' => [
+            [
+                'arg'  => 'directories <dir>',
+                'desc' => 'One or more specific directories to examine. Defaults to the directory from which the script is run.',
+            ],
+            [
+                'arg'  => '-q, --quiet',
+                'desc' => 'Turn off warnings for missing documentation.',
+            ],
+            [
+                'arg'  => '--exclude=<dir1,dir2>',
+                'desc' => 'Comma-delimited list of (relative) directories to exclude from the scan. Defaults to excluding the /vendor/ directory.',
+            ],
+            [
+                'arg'  => '--no-progress',
+                'desc' => 'Disable progress in console output.',
+            ],
+            [
+                'arg'  => '--colors',
+                'desc' => 'Enable colors in console output. (disables auto detection of color support)',
+            ],
+            [
+                'arg'  => '--no-colors',
+                'desc' => 'Disable colors in console output.',
+            ],
+            [
+                'arg'  => '-v',
+                'desc' => 'Verbose mode.',
+            ],
+            [
+                'arg'  => '-h, --help',
+                'desc' => 'Print this help.',
+            ],
+            [
+                'arg'  => '-V, --version',
+                'desc' => 'Display the current version of this script.',
+            ],
+        ],
+        // phpcs:enable
+    ];
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -114,7 +180,7 @@ final class Config
      */
     public function __get($name)
     {
-        if (isset($this->$name)) {
+        if (isset($this->$name) && $name !== 'helpTexts') {
             return $this->$name;
         }
 
@@ -130,7 +196,7 @@ final class Config
      */
     public function __isset($name)
     {
-        return isset($this->$name);
+        return isset($this->$name) && $name !== 'helpTexts';
     }
 
     /**
@@ -184,6 +250,14 @@ final class Config
 
         $argsFlipped = \array_flip($args);
 
+        if (isset($argsFlipped['--no-colors'])) {
+            $this->showColored = false;
+        } elseif (isset($argsFlipped['--colors'])) {
+            $this->showColored = true;
+        } else {
+            $this->showColored = $this->isColorSupported();
+        }
+
         if (isset($argsFlipped['-h'])
             || isset($argsFlipped['--help'])
         ) {
@@ -209,14 +283,6 @@ final class Config
 
         if (isset($argsFlipped['--no-progress'])) {
             $this->showProgress = false;
-        }
-
-        if (isset($argsFlipped['--no-colors'])) {
-            $this->showColored = false;
-        } elseif (isset($argsFlipped['--colors'])) {
-            $this->showColored = true;
-        } else {
-            $this->showColored = $this->isColorSupported();
         }
 
         if (isset($argsFlipped['-v'])) {
@@ -307,26 +373,58 @@ final class Config
      */
     private function getHelp()
     {
-        $text  = 'Usage:' . \PHP_EOL;
-        $text .= '    phpcs-check-feature-completeness' . \PHP_EOL;
-        $text .= '    phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]' . \PHP_EOL;
+        $output = '';
+        foreach ($this->helpTexts as $section => $options) {
+            $longestOptionLength = 0;
+            foreach ($options as $option) {
+                if (isset($option['arg'])) {
+                    $longestOptionLength = \max($longestOptionLength, \strlen($option['arg']));
+                }
+            }
 
-        $text .= \PHP_EOL;
-        $text .= 'Options:' . \PHP_EOL;
-        $text .= '    directories <dir>     One or more specific directories to examine.' . \PHP_EOL;
-        $text .= '                          Defaults to the directory from which the script is run.' . \PHP_EOL;
-        $text .= '    -q, --quiet           Turn off warnings for missing documentation.' . \PHP_EOL;
-        $text .= '    --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to' . \PHP_EOL;
-        $text .= '                          exclude from the scan.' . \PHP_EOL;
-        $text .= '                          Defaults to excluding the /vendor/ directory.' . \PHP_EOL;
-        $text .= '    --no-progress         Disable progress in console output.' . \PHP_EOL;
-        $text .= '    --colors              Enable colors in console output.' . \PHP_EOL;
-        $text .= '                          (disables auto detection of color support)' . \PHP_EOL;
-        $text .= '    --no-colors           Disable colors in console output.' . \PHP_EOL;
-        $text .= '    -v                    Verbose mode.' . \PHP_EOL;
-        $text .= '    -h, --help            Print this help.' . \PHP_EOL;
-        $text .= '    -V, --version         Display the current version of this script.' . \PHP_EOL;
+            if ($this->showColored === true) {
+                $output .= "\033[33m{$section}:\033[0m" . \PHP_EOL;
+            } else {
+                $output .= "{$section}:" . \PHP_EOL;
+            }
 
-        return $text;
+            $descWidth = (self::MAX_WIDTH - ($longestOptionLength + 1 + \strlen(self::LEFT_MARGIN)));
+            $descBreak = \PHP_EOL . self::LEFT_MARGIN . \str_pad(' ', ($longestOptionLength + 1));
+
+            foreach ($options as $option) {
+                if (isset($option['text'])) {
+                    $text = $option['text'];
+                    if ($this->showColored === true) {
+                        $text = \preg_replace('`(\[[^\]]+\])`', "\033[36m" . '$1' . "\033[0m", $text);
+                    }
+                    $output .= self::LEFT_MARGIN . $text . \PHP_EOL;
+                }
+
+                if (isset($option['arg'])) {
+                    $arg = \str_pad($option['arg'], $longestOptionLength);
+                    if ($this->showColored === true) {
+                        $arg = \preg_replace('`(<[^>]+>)`', "\033[0m\033[36m" . '$1', $arg);
+                        $arg = "\033[32m{$arg}\033[0m";
+                    }
+
+                    $descText = \wordwrap($option['desc'], $descWidth, $descBreak);
+                    $desc     = \explode('. ', $option['desc']);
+                    if (\count($desc) > 1) {
+                        $descText = '';
+                        foreach ($desc as $key => $sentence) {
+                            $descText .= ($key === 0) ? '' : $descBreak;
+                            $descText .= \wordwrap($sentence, $descWidth, $descBreak);
+                            $descText  = \rtrim($descText, '.') . '.';
+                        }
+                    }
+
+                    $output .= self::LEFT_MARGIN . $arg . ' ' . $descText . \PHP_EOL;
+                }
+            }
+
+            $output .= \PHP_EOL;
+        }
+
+        return $output;
     }
 }

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -313,19 +313,19 @@ final class Config
 
         $text .= \PHP_EOL;
         $text .= 'Options:' . \PHP_EOL;
-        $text .= '    directories   One or more specific directories to examine.' . \PHP_EOL;
-        $text .= '                  Defaults to the directory from which the script is run.' . \PHP_EOL;
-        $text .= '    -q, --quiet   Turn off warnings for missing documentation.' . \PHP_EOL;
-        $text .= '    --exclude     Comma-delimited list of (relative) directories to exclude' . \PHP_EOL;
-        $text .= '                  from the scan.' . \PHP_EOL;
-        $text .= '                  Defaults to excluding the /vendor/ directory.' . \PHP_EOL;
-        $text .= '    --no-progress Disable progress in console output.' . \PHP_EOL;
-        $text .= '    --colors      Enable colors in console output.' . \PHP_EOL;
-        $text .= '                  (disables auto detection of color support)' . \PHP_EOL;
-        $text .= '    --no-colors   Disable colors in console output.' . \PHP_EOL;
-        $text .= '    -v            Verbose mode.' . \PHP_EOL;
-        $text .= '    -h, --help    Print this help.' . \PHP_EOL;
-        $text .= '    -V, --version Display the current version of this script.' . \PHP_EOL;
+        $text .= '    directories <dir>     One or more specific directories to examine.' . \PHP_EOL;
+        $text .= '                          Defaults to the directory from which the script is run.' . \PHP_EOL;
+        $text .= '    -q, --quiet           Turn off warnings for missing documentation.' . \PHP_EOL;
+        $text .= '    --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to' . \PHP_EOL;
+        $text .= '                          exclude from the scan.' . \PHP_EOL;
+        $text .= '                          Defaults to excluding the /vendor/ directory.' . \PHP_EOL;
+        $text .= '    --no-progress         Disable progress in console output.' . \PHP_EOL;
+        $text .= '    --colors              Enable colors in console output.' . \PHP_EOL;
+        $text .= '                          (disables auto detection of color support)' . \PHP_EOL;
+        $text .= '    --no-colors           Disable colors in console output.' . \PHP_EOL;
+        $text .= '    -v                    Verbose mode.' . \PHP_EOL;
+        $text .= '    -h, --help            Print this help.' . \PHP_EOL;
+        $text .= '    -V, --version         Display the current version of this script.' . \PHP_EOL;
 
         return $text;
     }

--- a/Tests/FeatureComplete/Config/GetHelpTest.php
+++ b/Tests/FeatureComplete/Config/GetHelpTest.php
@@ -32,19 +32,19 @@ Usage:
     phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]
 
 Options:
-    directories   One or more specific directories to examine.
-                  Defaults to the directory from which the script is run.
-    -q, --quiet   Turn off warnings for missing documentation.
-    --exclude     Comma-delimited list of (relative) directories to exclude
-                  from the scan.
-                  Defaults to excluding the /vendor/ directory.
-    --no-progress Disable progress in console output.
-    --colors      Enable colors in console output.
-                  (disables auto detection of color support)
-    --no-colors   Disable colors in console output.
-    -v            Verbose mode.
-    -h, --help    Print this help.
-    -V, --version Display the current version of this script.';
+    directories <dir>     One or more specific directories to examine.
+                          Defaults to the directory from which the script is run.
+    -q, --quiet           Turn off warnings for missing documentation.
+    --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
+                          exclude from the scan.
+                          Defaults to excluding the /vendor/ directory.
+    --no-progress         Disable progress in console output.
+    --colors              Enable colors in console output.
+                          (disables auto detection of color support)
+    --no-colors           Disable colors in console output.
+    -v                    Verbose mode.
+    -h, --help            Print this help.
+    -V, --version         Display the current version of this script.';
 
     /**
      * Verify the "show help" command generates the expected output.

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -11,19 +11,19 @@
  *     phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]
  *
  * Options:
- *     directories   One or more specific directories to examine.
- *                   Defaults to the directory from which the script is run.
- *     -q, --quiet   Turn off warnings for missing documentation.
- *     --exclude     Comma-delimited list of (relative) directories to exclude
- *                   from the scan.
- *                   Defaults to excluding the /vendor/ directory.
- *     --no-progress Disable progress in console output.
- *     --colors      Enable colors in console output.
- *                   (disables auto detection of color support)
- *     --no-colors   Disable colors in console output.
- *     -v            Verbose mode.
- *     -h, --help    Print this help.
- *     -V, --version Display the current version of this script.
+ *     directories <dir>     One or more specific directories to examine.
+ *                           Defaults to the directory from which the script is run.
+ *     -q, --quiet           Turn off warnings for missing documentation.
+ *     --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
+ *                           exclude from the scan.
+ *                           Defaults to excluding the /vendor/ directory.
+ *     --no-progress         Disable progress in console output.
+ *     --colors              Enable colors in console output.
+ *                           (disables auto detection of color support)
+ *     --no-colors           Disable colors in console output.
+ *     -v                    Verbose mode.
+ *     -h, --help            Print this help.
+ *     -V, --version         Display the current version of this script.
  *
  * @package   PHPCSDevTools
  * @copyright 2019 PHPCSDevTools Contributors

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -7,23 +7,23 @@
  * be used both on PHPCS itself as well as by external standards.
  *
  * Usage:
- *     phpcs-check-feature-completeness
- *     phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]
+ *   phpcs-check-feature-completeness
+ *   phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]
  *
  * Options:
- *     directories <dir>     One or more specific directories to examine.
- *                           Defaults to the directory from which the script is run.
- *     -q, --quiet           Turn off warnings for missing documentation.
- *     --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
- *                           exclude from the scan.
- *                           Defaults to excluding the /vendor/ directory.
- *     --no-progress         Disable progress in console output.
- *     --colors              Enable colors in console output.
- *                           (disables auto detection of color support)
- *     --no-colors           Disable colors in console output.
- *     -v                    Verbose mode.
- *     -h, --help            Print this help.
- *     -V, --version         Display the current version of this script.
+ *   directories <dir>     One or more specific directories to examine.
+ *                         Defaults to the directory from which the script is run.
+ *   -q, --quiet           Turn off warnings for missing documentation.
+ *   --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
+ *                         exclude from the scan.
+ *                         Defaults to excluding the /vendor/ directory.
+ *   --no-progress         Disable progress in console output.
+ *   --colors              Enable colors in console output.
+ *                         (disables auto detection of color support)
+ *   --no-colors           Disable colors in console output.
+ *   -v                    Verbose mode.
+ *   -h, --help            Print this help.
+ *   -V, --version         Display the current version of this script.
  *
  * @package   PHPCSDevTools
  * @copyright 2019 PHPCSDevTools Contributors


### PR DESCRIPTION
### FeatureComplete/Config::getHelp(): improve help texts

Include more information about how the options are supposed to be used.

Includes updating the test to match the new expected output.

### FeatureComplete/Config::getHelp(): allow for color highlighted help texts

This commit adds color highlighting to the help text output when color output is enabled via `--colors` or when color support is auto-detected.

* The parsing of the color support CLI options has been placed ahead of the parsing of the help related arguments to allow for the `getHelp()` function to know whether or not to colorize the texts.
* As parts of each line of the help text will potentially need to be colorized, the actual help texts have been put in an array and moved to a property.
    This property is explicitly excluded from retrieval via the magic methods.
* The text to display is no longer hard-coded, but is generated based on the help texts array.
    - The section headers will be colorized if supported.
    - The CLI arguments will be colorized if supported.
    - The CLI arguments and the descriptions will be shown in columns based on the longest CLI argument text length.
    - The description text will be automatically wrapped to respect the `MAX_WIDTH`.

Includes updating the existing tests (smaller left margin) and adding a new test specifically for the colorized output.