### PR TITLE
FeatureComplete/Check: improve usability/readability of reporting in CLI

### DIFF
--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -243,12 +243,29 @@ final class Check
          * Show feedback to the user.
          */
         if (empty($notices) === false) {
+            $template = 'Found %1$s%2$d error%3$s%4$s and %5$s%6$d warning%7$s%8$s.';
+            if ($this->config->quietMode === true) {
+                $template = 'Found %1$s%2$d error%3$s%4$s.';
+            }
+
             // Show the errors and warnings.
+            $summary = \sprintf(
+                $template,
+                ($errorCount > 0 && $this->config->showColored === true) ? "\033[31m" : '',
+                $errorCount,
+                ($errorCount === 1) ? '' : 's',
+                ($errorCount > 0 && $this->config->showColored === true) ? "\033[0m" : '',
+                ($warningCount > 0 && $this->config->showColored === true) ? "\033[33m" : '',
+                $warningCount,
+                ($warningCount === 1) ? '' : 's',
+                ($warningCount > 0 && $this->config->showColored === true) ? "\033[0m" : ''
+            );
+
             echo \PHP_EOL,
                 \implode(\PHP_EOL, $notices), \PHP_EOL,
                 \PHP_EOL,
                 \str_repeat('-', 39), \PHP_EOL,
-                \sprintf('Found %d errors and %d warnings', $errorCount, $warningCount), \PHP_EOL;
+                $summary, \PHP_EOL;
 
             return false;
         } else {

--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -175,9 +175,9 @@ final class Check
             return true;
         }
 
-        $docWarning    = 'WARNING: Documentation missing for %s.';
-        $testError     = 'ERROR: Unit tests missing for %s.';
-        $testCaseError = 'ERROR: Unit test case file missing for %s.';
+        $docWarning    = 'WARNING: Documentation missing for       %s';
+        $testError     = 'ERROR:   Unit tests missing for          %s';
+        $testCaseError = 'ERROR:   Unit test case file missing for %s';
 
         if ($this->config->showColored === true) {
             $docWarning    = \str_replace('WARNING', "\033[33mWARNING\033[0m", $docWarning);
@@ -247,7 +247,7 @@ final class Check
             echo \PHP_EOL,
                 \implode(\PHP_EOL, $notices), \PHP_EOL,
                 \PHP_EOL,
-                '-----------------------------------------', \PHP_EOL,
+                \str_repeat('-', 39), \PHP_EOL,
                 \sprintf('Found %d errors and %d warnings', $errorCount, $warningCount), \PHP_EOL;
 
             return false;

--- a/Tests/FeatureComplete/Check/ColorTest.php
+++ b/Tests/FeatureComplete/Check/ColorTest.php
@@ -37,12 +37,13 @@ final class ColorTest extends CheckTestCase
      * @param string $fixtureDir     Relative path within the fixture directory to use for the test.
      * @param string $expectedOutput Colorized snippet of the expected output.
      * @param int    $exitCode       The expected exit code.
+     * @param string $cliExtra       Optional. Additional CLI arguments to pass.
      *
      * @return void
      */
-    public function testColors($fixtureDir, $expectedOutput, $exitCode)
+    public function testColors($fixtureDir, $expectedOutput, $exitCode, $cliExtra = '')
     {
-        $command = 'phpcs-check-feature-completeness --colors ' . self::FIXTURE_DIR . $fixtureDir;
+        $command = 'phpcs-check-feature-completeness --colors ' . $cliExtra . ' ' . self::FIXTURE_DIR . $fixtureDir;
         $regex   = '`' .  \preg_quote($expectedOutput, '`') . '`';
 
         $this->runValidation($command, $regex, $exitCode);
@@ -70,6 +71,27 @@ final class ColorTest extends CheckTestCase
                 'fixtureDir'     => 'ValidStandards/CompleteSingleSniff',
                 'expectedOutput' => "\033[32mFound 1 sniff accompanied by unit tests and documentation.\033[0m",
                 'exitCode'       => 0,
+            ],
+            'feature complete - summary: has errors and warnings' => [
+                'fixtureDir'     => 'MissingTestsAndDocs/MultipleSniffs',
+                'expectedOutput' => "Found \033[31m3 errors\033[0m and \033[33m2 warnings\033[0m.",
+                'exitCode'       => 1,
+            ],
+            'feature complete - summary: has errors, no warnings' => [
+                'fixtureDir'     => 'MissingTestFiles/MultipleSniffs',
+                'expectedOutput' => "Found \033[31m3 errors\033[0m and 0 warnings.",
+                'exitCode'       => 1,
+            ],
+            'feature complete - summary: no errors, has warnings' => [
+                'fixtureDir'     => 'MissingDocFiles/MultipleSniffs',
+                'expectedOutput' => "Found 0 errors and \033[33m2 warnings\033[0m.",
+                'exitCode'       => 1,
+            ],
+            'feature complete - summary: quiet mode - has errors' => [
+                'fixtureDir'     => 'MissingTestsAndDocs/MultipleSniffs',
+                'expectedOutput' => "Found \033[31m3 errors\033[0m",
+                'exitCode'       => 1,
+                'cliExtra'       => '-q',
             ],
         ];
     }

--- a/Tests/FeatureComplete/Check/MissingDocFilesTest.php
+++ b/Tests/FeatureComplete/Check/MissingDocFilesTest.php
@@ -65,10 +65,10 @@ final class MissingDocFilesTest extends CheckTestCase
 
 \.{3} 3 / 3 \(100%\)
 
-WARNING: Documentation missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php\.
-WARNING: Documentation missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php\.
+WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php
+WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
------------------------------------------
+---------------------------------------
 Found 0 errors and 2 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
@@ -91,11 +91,11 @@ Found 0 errors and 2 warnings[\r\n]+$`';
 
 \.{4} 4 / 4 \(100%\)
 
-WARNING: Documentation missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php\.
-WARNING: Documentation missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php\.
-WARNING: Documentation missing for ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php\.
+WARNING: Documentation missing for       ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php
+WARNING: Documentation missing for       ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php
+WARNING: Documentation missing for       ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php
 
------------------------------------------
+---------------------------------------
 Found 0 errors and 3 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
@@ -115,9 +115,9 @@ Found 0 errors and 3 warnings[\r\n]+$`';
 
 \. 1 / 1 \(100%\)
 
-WARNING: Documentation missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
+WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
 
------------------------------------------
+---------------------------------------
 Found 0 errors and 1 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);

--- a/Tests/FeatureComplete/Check/MissingDocFilesTest.php
+++ b/Tests/FeatureComplete/Check/MissingDocFilesTest.php
@@ -69,7 +69,7 @@ WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]O
 WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
 ---------------------------------------
-Found 0 errors and 2 warnings[\r\n]+$`';
+Found 0 errors and 2 warnings\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }
@@ -96,7 +96,7 @@ WARNING: Documentation missing for       ' . $sniffDir1Regex . 'CategoryB[\\\\/]
 WARNING: Documentation missing for       ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php
 
 ---------------------------------------
-Found 0 errors and 3 warnings[\r\n]+$`';
+Found 0 errors and 3 warnings\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }
@@ -118,7 +118,7 @@ Found 0 errors and 3 warnings[\r\n]+$`';
 WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
 
 ---------------------------------------
-Found 0 errors and 1 warnings[\r\n]+$`';
+Found 0 errors and 1 warning\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }

--- a/Tests/FeatureComplete/Check/MissingTestFilesTest.php
+++ b/Tests/FeatureComplete/Check/MissingTestFilesTest.php
@@ -70,7 +70,7 @@ ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]O
 ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
 ---------------------------------------
-Found 3 errors and 0 warnings[\r\n]$`';
+Found 3 errors and 0 warnings\.[\r\n]$`';
 
         $this->runValidation($command, $regex, 1);
     }
@@ -98,7 +98,7 @@ ERROR:   Unit tests missing for          ' . $sniffDir1Regex . 'CategoryB[\\\\/]
 ERROR:   Unit test case file missing for ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php
 
 ---------------------------------------
-Found 4 errors and 0 warnings[\r\n]$`';
+Found 4 errors and 0 warnings\.[\r\n]$`';
 
         $this->runValidation($command, $regex, 1);
     }
@@ -120,13 +120,14 @@ Found 4 errors and 0 warnings[\r\n]$`';
 ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
 
 ---------------------------------------
-Found 1 errors and 0 warnings[\r\n]+$`';
+Found 1 error and 0 warnings\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }
 
     /**
-     * Verify that enabling the "quiet" option still reports on missing tests.
+     * Verify that enabling the "quiet" option still reports on missing tests, but does adjust
+     * the "summary" to only mention errors.
      *
      * @return void
      */
@@ -144,7 +145,7 @@ ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]O
 ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
 ---------------------------------------
-Found 3 errors and 0 warnings[\r\n]+$`';
+Found 3 errors\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }

--- a/Tests/FeatureComplete/Check/MissingTestFilesTest.php
+++ b/Tests/FeatureComplete/Check/MissingTestFilesTest.php
@@ -65,11 +65,11 @@ final class MissingTestFilesTest extends CheckTestCase
 
 \.{3} 3 / 3 \(100%\)
 
-ERROR: Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php\.
+ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
------------------------------------------
+---------------------------------------
 Found 3 errors and 0 warnings[\r\n]$`';
 
         $this->runValidation($command, $regex, 1);
@@ -92,12 +92,12 @@ Found 3 errors and 0 warnings[\r\n]$`';
 
 \.{4} 4 / 4 \(100%\)
 
-ERROR: Unit test case file missing for ' . $sniffDir1Regex . 'CategoryA[\\\\/]DummySniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php\.
-ERROR: Unit test case file missing for ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php\.
+ERROR:   Unit test case file missing for ' . $sniffDir1Regex . 'CategoryA[\\\\/]DummySniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php
+ERROR:   Unit test case file missing for ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php
 
------------------------------------------
+---------------------------------------
 Found 4 errors and 0 warnings[\r\n]$`';
 
         $this->runValidation($command, $regex, 1);
@@ -117,9 +117,9 @@ Found 4 errors and 0 warnings[\r\n]$`';
 
 \. 1 / 1 \(100%\)
 
-ERROR: Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
+ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
 
------------------------------------------
+---------------------------------------
 Found 1 errors and 0 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
@@ -139,11 +139,11 @@ Found 1 errors and 0 warnings[\r\n]+$`';
 
 \.{3} 3 / 3 \(100%\)
 
-ERROR: Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php\.
+ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
------------------------------------------
+---------------------------------------
 Found 3 errors and 0 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);

--- a/Tests/FeatureComplete/Check/MissingTestsAndDocsTest.php
+++ b/Tests/FeatureComplete/Check/MissingTestsAndDocsTest.php
@@ -72,7 +72,7 @@ WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]T
 ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
 ---------------------------------------
-Found 3 errors and 2 warnings[\r\n]+$`';
+Found 3 errors and 2 warnings\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }
@@ -104,7 +104,7 @@ WARNING: Documentation missing for       ' . $sniffDir2Regex . 'CategoryA[\\\\/]
 ERROR:   Unit tests missing for          ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php
 
 ---------------------------------------
-Found 4 errors and 3 warnings[\r\n]+$`';
+Found 4 errors and 3 warnings\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }
@@ -127,13 +127,15 @@ WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryA[\\\\/]D
 ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
 
 ---------------------------------------
-Found 1 errors and 1 warnings[\r\n]+$`';
+Found 1 error and 1 warning\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }
 
     /**
      * Verify that enabling the "quiet" option still reports on missing tests, but no longer reports on missing docs.
+     *
+     * Includes verification that the "summary" message no longer mentions warnings.
      *
      * @return void
      */
@@ -151,7 +153,7 @@ ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]O
 ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
 ---------------------------------------
-Found 3 errors and 0 warnings[\r\n]+$`';
+Found 3 errors\.[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
     }

--- a/Tests/FeatureComplete/Check/MissingTestsAndDocsTest.php
+++ b/Tests/FeatureComplete/Check/MissingTestsAndDocsTest.php
@@ -65,13 +65,13 @@ final class MissingTestsAndDocsTest extends CheckTestCase
 
 \.{3} 3 / 3 \(100%\)
 
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
-WARNING: Documentation missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php\.
-ERROR: Unit test case file missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php\.
-WARNING: Documentation missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php\.
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
+WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php
+ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php
+WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
------------------------------------------
+---------------------------------------
 Found 3 errors and 2 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
@@ -95,15 +95,15 @@ Found 3 errors and 2 warnings[\r\n]+$`';
 
 \.{4} 4 / 4 \(100%\)
 
-ERROR: Unit tests missing for ' . $sniffDir1Regex . 'CategoryA[\\\\/]DummySniff\.php\.
-WARNING: Documentation missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php\.
-ERROR: Unit test case file missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php\.
-WARNING: Documentation missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php\.
-WARNING: Documentation missing for ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php\.
+ERROR:   Unit tests missing for          ' . $sniffDir1Regex . 'CategoryA[\\\\/]DummySniff\.php
+WARNING: Documentation missing for       ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php
+ERROR:   Unit test case file missing for ' . $sniffDir1Regex . 'CategoryB[\\\\/]OneSniff\.php
+WARNING: Documentation missing for       ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDir1Regex . 'CategoryB[\\\\/]TwoSniff\.php
+WARNING: Documentation missing for       ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDir2Regex . 'CategoryA[\\\\/]DummySniff\.php
 
------------------------------------------
+---------------------------------------
 Found 4 errors and 3 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
@@ -123,10 +123,10 @@ Found 4 errors and 3 warnings[\r\n]+$`';
 
 \. 1 / 1 \(100%\)
 
-WARNING: Documentation missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
+WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
 
------------------------------------------
+---------------------------------------
 Found 1 errors and 1 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);
@@ -146,11 +146,11 @@ Found 1 errors and 1 warnings[\r\n]+$`';
 
 \.{3} 3 / 3 \(100%\)
 
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php\.
-ERROR: Unit test case file missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php\.
-ERROR: Unit tests missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php\.
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryA[\\\\/]DummySniff\.php
+ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryB[\\\\/]OneSniff\.php
+ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]TwoSniff\.php
 
------------------------------------------
+---------------------------------------
 Found 3 errors and 0 warnings[\r\n]+$`';
 
         $this->runValidation($command, $regex, 1);


### PR DESCRIPTION
### FeatureComplete/Check: improve individual error/warning display

* Align the various parts of the error/warning messages for improved readability.
* Make the "horizontal rule" above the summary match the length of the first two "columns".
* Don't have a period `.` after the file name as it may confuse CLI interfaces which allow for clicking through to the file.

Tested via the (adjusted) existing unit tests.

### FeatureComplete/Check: improve error/warning summary display

Improve error/warning summary:
* Display the correct singular "error"/"warning" vs plural "errors"/"warnings" depending on the number of errors/warnings found.
* Only mention "warnings" when not in quiet mode. I.e. when warnings are actually a possibility.
* Colorize the "# errors" and "# warnings" part of the summary message.
* Minor punctuation fix for the summary.

Tested via the (adjusted) existing unit tests + added specific tests for the coloring of the summary to the `ColorTest` file.