### PR TITLE
FeatureComplete: add explicit `--no-docs` CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ phpcs-check-feature-completeness ./StandardName
 directories <dir>     One or more specific directories to examine.
                       Defaults to the directory from which the script is run.
 -q, --quiet           Turn off warnings for missing documentation.
+                      Equivalent to running with "--no-docs".
 --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
                       exclude from the scan.
                       Defaults to excluding the /vendor/ directory.
+--no-docs             Disable missing documentation check.
 --no-progress         Disable progress in console output.
 --colors              Enable colors in console output.
                       (disables auto detection of color support)

--- a/Scripts/FeatureComplete/Check.php
+++ b/Scripts/FeatureComplete/Check.php
@@ -189,7 +189,7 @@ final class Check
         $warningCount = 0;
         $errorCount   = 0;
         foreach ($this->allSniffs as $i => $file) {
-            if ($this->config->quietMode === false) {
+            if ($this->config->checkDocs === true) {
                 $docFile = \str_replace(\array_keys($this->sniffToDoc), $this->sniffToDoc, $file);
                 if (isset($this->allFiles[$docFile]) === false) {
                     $notices[] = \sprintf($docWarning, $file);
@@ -244,7 +244,7 @@ final class Check
          */
         if (empty($notices) === false) {
             $template = 'Found %1$s%2$d error%3$s%4$s and %5$s%6$d warning%7$s%8$s.';
-            if ($this->config->quietMode === true) {
+            if ($this->config->checkDocs === false) {
                 $template = 'Found %1$s%2$d error%3$s%4$s.';
             }
 
@@ -274,7 +274,7 @@ final class Check
                 $feedback = "Found $sniffCount sniff";
             }
 
-            if ($this->config->quietMode === false) {
+            if ($this->config->checkDocs === true) {
                 $feedback .= ' accompanied by unit tests and documentation.';
             } else {
                 $feedback .= ' accompanied by unit tests.';

--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -46,16 +46,14 @@ final class Config
     private $projectRoot = '';
 
     /**
-     * Whether to use "quiet" mode.
+     * Whether or not to check the documentation completeness.
      *
-     * This will silence all warnings, but still show the errors.
-     *
-     * To enable "quiet" mode, pass `-q` on the command line when calling
-     * the script.
+     * To disable checking for documentation, pass `--no-docs` on the command line
+     * when calling the script or use "quiet" mode by passing `-q`.
      *
      * @var bool
      */
-    private $quietMode = false;
+    protected $checkDocs = true;
 
     /**
      * Whether or not to show progress.
@@ -124,11 +122,15 @@ final class Config
             ],
             [
                 'arg'  => '-q, --quiet',
-                'desc' => 'Turn off warnings for missing documentation.',
+                'desc' => 'Turn off warnings for missing documentation. Equivalent to running with "--no-docs".',
             ],
             [
                 'arg'  => '--exclude=<dir1,dir2>',
                 'desc' => 'Comma-delimited list of (relative) directories to exclude from the scan. Defaults to excluding the /vendor/ directory.',
+            ],
+            [
+                'arg'  => '--no-docs',
+                'desc' => 'Disable missing documentation check.',
             ],
             [
                 'arg'  => '--no-progress',
@@ -278,7 +280,11 @@ final class Config
         if (isset($argsFlipped['-q'])
             || isset($argsFlipped['--quiet'])
         ) {
-            $this->quietMode = true;
+            $this->checkDocs = false;
+        }
+
+        if (isset($argsFlipped['--no-docs'])) {
+            $this->checkDocs = false;
         }
 
         if (isset($argsFlipped['--no-progress'])) {

--- a/Tests/FeatureComplete/Config/GetHelpTest.php
+++ b/Tests/FeatureComplete/Config/GetHelpTest.php
@@ -36,9 +36,11 @@ Options:
   directories <dir>     One or more specific directories to examine.
                         Defaults to the directory from which the script is run.
   -q, --quiet           Turn off warnings for missing documentation.
+                        Equivalent to running with "--no-docs".
   --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
                         exclude from the scan.
                         Defaults to excluding the /vendor/ directory.
+  --no-docs             Disable missing documentation check.
   --no-progress         Disable progress in console output.
   --colors              Enable colors in console output.
                         (disables auto detection of color support).
@@ -60,9 +62,11 @@ Options:
   \033[32mdirectories \033[0m\033[36m<dir>    \033[0m One or more specific directories to examine.
                         Defaults to the directory from which the script is run.
   \033[32m-q, --quiet          \033[0m Turn off warnings for missing documentation.
+                        Equivalent to running with \"--no-docs\".
   \033[32m--exclude=\033[0m\033[36m<dir1,dir2>\033[0m Comma-delimited list of (relative) directories to
                         exclude from the scan.
                         Defaults to excluding the /vendor/ directory.
+  \033[32m--no-docs            \033[0m Disable missing documentation check.
   \033[32m--no-progress        \033[0m Disable progress in console output.
   \033[32m--colors             \033[0m Enable colors in console output.
                         (disables auto detection of color support).

--- a/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
+++ b/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
@@ -31,7 +31,7 @@ final class ProcessCliCommandTest extends TestCase
      */
     private $defaultSettings = [
         'projectRoot'  => '',
-        'quietMode'    => false,
+        'checkDocs'    => true,
         'showProgress' => true,
         'showColored'  => null,
         'verbose'      => 0,
@@ -186,7 +186,7 @@ final class ProcessCliCommandTest extends TestCase
                 'command'         => 'phpcs-check-feature-completeness -q -v .',
                 'expectedChanged' => [
                     'projectRoot' => $projectRoot,
-                    'quietMode'   => true,
+                    'checkDocs'   => false,
                     'verbose'     => 1,
                     'targetDirs'  => [
                         \realpath('.'),
@@ -254,7 +254,7 @@ final class ProcessCliCommandTest extends TestCase
                 'command'         => './phpcs-check-feature-completeness -q',
                 'expectedChanged' => [
                     'projectRoot' => $projectRoot,
-                    'quietMode'   => true,
+                    'checkDocs'   => false,
                     'targetDirs'  => [
                         $projectRoot,
                     ],
@@ -264,9 +264,19 @@ final class ProcessCliCommandTest extends TestCase
                 'command'         => 'aliased-command --quiet',
                 'expectedChanged' => [
                     'projectRoot' => $projectRoot,
-                    'quietMode'   => true,
+                    'checkDocs'   => false,
                     'targetDirs'  => [
                         $projectRoot,
+                    ],
+                ],
+            ],
+            'No docs' => [
+                'command'         => 'phpcs-check-feature-completeness . --no-docs',
+                'expectedChanged' => [
+                    'projectRoot'  => $projectRoot,
+                    'checkDocs'    => false,
+                    'targetDirs'   => [
+                        \realpath('.'),
                     ],
                 ],
             ],
@@ -317,7 +327,7 @@ final class ProcessCliCommandTest extends TestCase
                     . ' PHPCSDebug   --no-progress    ./Tests   --colors -v .',
                 'expectedChanged'  => [
                     'projectRoot'  => $projectRoot,
-                    'quietMode'    => true,
+                    'checkDocs'   => false,
                     'showProgress' => false,
                     'showColored'  => true,
                     'verbose'      => 1,

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -14,9 +14,11 @@
  *   directories <dir>     One or more specific directories to examine.
  *                         Defaults to the directory from which the script is run.
  *   -q, --quiet           Turn off warnings for missing documentation.
+ *                         Equivalent to running with "--no-docs".
  *   --exclude=<dir1,dir2> Comma-delimited list of (relative) directories to
  *                         exclude from the scan.
  *                         Defaults to excluding the /vendor/ directory.
+ *   --no-docs             Disable missing documentation check.
  *   --no-progress         Disable progress in console output.
  *   --colors              Enable colors in console output.
  *                         (disables auto detection of color support)


### PR DESCRIPTION
* Add explicit `--no-docs` CLI option. Currently this is basically an alias for the `-q`/`--quiet` option.
* Remove the `Config::$quietMode` property in favour of a `Config::$checkDocs` property and adjust all places the old property was used.

Includes:
* Adding a dedicated test to safeguard the parsing of the new CLI argument.
* Updating the CLI arguments lists in all relevant places.
* Updating existing `GetHelpTest` tests for the new CLI argument.
* Updating existing unit tests for the property rename.