### PR TITLE
Add autoloading for non-sniff related files

### DIFF
--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -35,14 +35,21 @@
  * @link      https://github.com/PHPCSStandards/PHPCSDevTools
  */
 
-if (is_file(__DIR__.'/../autoload.php') === true) {
-    // Installed via Composer.
-    require_once __DIR__.'/../autoload.php';
-} else {
-    // Presume git clone.
-    require_once __DIR__ . '/../Scripts/Utils/FileList.php';
-    require_once __DIR__ . '/../Scripts/FeatureComplete/Config.php';
-    require_once __DIR__ . '/../Scripts/FeatureComplete/Check.php';
+$autoloadLocations = [
+    __DIR__ . '/../devtools-autoload.php', // Git clone or direct run from within vendor package directory.
+    __DIR__ . '/../phpcsstandards/phpcsdevtools/devtools-autoload.php', // Composer bin dir install.
+    __DIR__ . '/../autoload.php', // Try Composer autoload from a bin dir install.
+    __DIR__ . '/../../../autoload.php', // Try Composer autoload from within vendor package directory.
+    __DIR__ . '/../vendor/autoload.php', // Try Composer autoload from a git clone install.
+];
+
+// Try and find a usable autoload file.
+foreach ($autoloadLocations as $file) {
+    $file = realpath($file);
+    if ($file !== false && is_file($file) === true) {
+        require_once($file);
+        break;
+    }
 }
 
 $config = new PHPCSDevTools\Scripts\FeatureComplete\Config();

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,11 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
+    "autoload" : {
+        "psr-4": {
+            "PHPCSDevTools\\Scripts\\": "Scripts/"
+        }
+    },
     "autoload-dev" : {
         "psr-4": {
             "PHPCSDevTools\\Tests\\": "Tests/"

--- a/devtools-autoload.php
+++ b/devtools-autoload.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+if (defined('PHPCSDEVTOOLS_AUTOLOAD') === false) {
+    /*
+     * Register an autoloader.
+     *
+     * This autoloader handles the loading of all classes and interfaces
+     * in this repo.
+     *
+     * Note: The autoloading of the PHPCSDebug standard can be handled without problem by PHPCS,
+     * so a directive to load this autoload file is not included in the PHPCSDebug ruleset.
+     */
+    spl_autoload_register(function ($fqClassName) {
+        // Only try & load our own classes.
+        if (stripos($fqClassName, 'PHPCSDevtools\\') !== 0) {
+            return false;
+        }
+
+        // Don't load PHPCS sniff files to prevent interference with the PHPCS native autoloader.
+        if (stripos($fqClassName, 'PHPCSDevtools\\PHPCSDebug\\') === 0) {
+            return false;
+        }
+
+        $file = realpath(__DIR__ . strtr(substr($fqClassName, 13), '\\', '/') . '.php');
+
+        if (file_exists($file) === true) {
+            include_once $file;
+            return true;
+        }
+
+        return false;
+    });
+
+    define('PHPCSDEVTOOLS_AUTOLOAD', true);
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -54,6 +54,7 @@
     -->
 
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>/devtools-autoload\.php$</exclude-pattern>
         <exclude-pattern>/phpunit-bootstrap\.php$</exclude-pattern>
     </rule>
 

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -87,16 +87,11 @@ pointing to the PHPCSUtils directory.
     die(1);
 }
 
+// Load autoloader for the non-sniff devtools and tests.
+require_once __DIR__ . '/devtools-autoload.php';
+
 // Load test related autoloader.
 require_once __DIR__ . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
-
-// Load the scripts for the Feature Complete tooling.
-require_once __DIR__ . '/Scripts/Utils/FileList.php';
-require_once __DIR__ . '/Scripts/FeatureComplete/Config.php';
-require_once __DIR__ . '/Scripts/FeatureComplete/Check.php';
-
-// Load test related files.
-require_once __DIR__ . '/Tests/FeatureComplete/Check/CheckTestCase.php';
 
 // Clean up.
 unset($ds, $phpcsDir, $phpcsUtilsDir, $vendorDir);


### PR DESCRIPTION
PHP_CodeSniffer can and will handle the autoloading of the sniff file (and associated tests) via its own custom autoloader. For sniff files the PHPCS native autoloader is preferred as otherwise PHPCS cannot translate class names to sniff names.

For the other (non-test) files in this package, no autoloading was put in place yet.

This commit:
* Introduces a custom, PSR-4 based autoloader to handle loading all other files.
    This autoloader explicitly does not load the sniff file(s).
* Introduces a fall-back by setting the autoload directive in the `composer.json` file.
* Implements use of the custom autoloader in the `bin/phpcs-check-feature-completeness` script.
    The custom autoloader is preferred, but multiple autoload locations are tried in an attempt to find a usable autoload file.
* Implements use of the custom autoloader in the test bootstrap file.

Includes minor tweak to the CS ruleset to allow for the autoloader.