### PR TITLE
FeatureComplete: send report to STDOUT and progress/verbose output to STDERR

### DIFF
--- a/Scripts/FeatureComplete/Config.php
+++ b/Scripts/FeatureComplete/Config.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSDevTools\Scripts\FeatureComplete;
 
+use PHPCSDevTools\Scripts\Utils\Writer;
 use RuntimeException;
 
 /**
@@ -37,6 +38,13 @@ final class Config
      * @var string
      */
     const LEFT_MARGIN = '  ';
+
+    /**
+     * Writer for sending output.
+     *
+     * @var \PHPCSDevTools\Scripts\Utils\Writer
+     */
+    private $writer;
 
     /**
      * The root directory of the project.
@@ -176,9 +184,13 @@ final class Config
 
     /**
      * Constructor.
+     *
+     * @param \PHPCSDevTools\Scripts\Utils\Writer $writer Writer for sending output.
      */
-    public function __construct()
+    public function __construct(Writer $writer)
     {
+        $this->writer = $writer;
+
         $this->processCliCommand();
 
         if ($this->executeCheck === true && empty($this->targetDirs)) {
@@ -196,7 +208,10 @@ final class Config
      */
     public function __get($name)
     {
-        if (isset($this->$name) && $name !== 'helpTexts') {
+        if (isset($this->$name)
+            && $name !== 'helpTexts'
+            && $name !== 'writer'
+        ) {
             return $this->$name;
         }
 
@@ -212,7 +227,7 @@ final class Config
      */
     public function __isset($name)
     {
-        return isset($this->$name) && $name !== 'helpTexts';
+        return isset($this->$name) && $name !== 'helpTexts' && $name !== 'writer';
     }
 
     /**
@@ -277,8 +292,8 @@ final class Config
         if (isset($argsFlipped['-h'])
             || isset($argsFlipped['--help'])
         ) {
-            echo $this->getVersion();
-            echo $this->getHelp();
+            $this->writer->toStderr($this->getVersion());
+            $this->writer->toStdout($this->getHelp());
             $this->executeCheck = false;
             return;
         }
@@ -286,7 +301,7 @@ final class Config
         if (isset($argsFlipped['-V'])
             || isset($argsFlipped['--version'])
         ) {
-            echo $this->getVersion();
+            $this->writer->toStdout($this->getVersion());
             $this->executeCheck = false;
             return;
         }

--- a/Scripts/Utils/CliWriter.php
+++ b/Scripts/Utils/CliWriter.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Scripts\Utils;
+
+use PHPCSDevTools\Scripts\Utils\Writer;
+
+/**
+ * Utilities for writing to the command line.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is not part of the public API. Backward compatibility is not guaranteed.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @codeCoverageIgnore
+ *
+ * @since 2.0.0
+ */
+final class CliWriter implements Writer
+{
+
+    /**
+     * Send output to STDOUT.
+     *
+     * @param string $text Output to send.
+     *
+     * @return void
+     */
+    public function toStdout($text)
+    {
+        \fwrite(\STDOUT, $text);
+    }
+
+    /**
+     * Send output to STDERR.
+     *
+     * @param string $text Output to send.
+     *
+     * @return void
+     */
+    public function toStderr($text)
+    {
+        \fwrite(\STDERR, $text);
+    }
+}

--- a/Scripts/Utils/Writer.php
+++ b/Scripts/Utils/Writer.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Scripts\Utils;
+
+/**
+ * Text writer interface
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This interface is not part of the public API. Backward compatibility is not guaranteed.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @since 2.0.0
+ */
+interface Writer
+{
+
+    /**
+     * Send output to STDOUT.
+     *
+     * @param string $text Output to send.
+     *
+     * @return void
+     */
+    public function toStdout($text);
+
+    /**
+     * Send output to STDERR.
+     *
+     * @param string $text Output to send.
+     *
+     * @return void
+     */
+    public function toStderr($text);
+}

--- a/Tests/FeatureComplete/Check/CheckTestCase.php
+++ b/Tests/FeatureComplete/Check/CheckTestCase.php
@@ -12,12 +12,13 @@ namespace PHPCSDevTools\Tests\FeatureComplete\Check;
 
 use PHPCSDevTools\Scripts\FeatureComplete\Config;
 use PHPCSDevTools\Scripts\FeatureComplete\Check;
-use PHPUnit\Framework\TestCase;
+use PHPCSDevTools\Tests\TestWriter;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
  * Abstract test case for integration testing the Check class.
  */
-abstract class CheckTestCase extends TestCase
+abstract class CheckTestCase extends XTestCase
 {
 
     /**
@@ -33,12 +34,18 @@ abstract class CheckTestCase extends TestCase
     {
         // Make the regex ignore differences in line endings.
         $expectedOutputRegex = \preg_replace('`[\r\n]+`', '[\r\n]+', $expectedOutputRegex);
-        $this->expectOutputRegex($expectedOutputRegex);
 
         $_SERVER['argv'] = \explode(' ', $command);
-        $config          = new Config();
-        $check           = new Check($config);
+        $writer          = new TestWriter();
+        $config          = new Config($writer);
+        $check           = new Check($config, $writer);
+        $exitCode        = $check->validate();
 
-        $this->assertSame($expectedExitcode, $check->validate(), 'Exit code does not match expectation');
+        $this->assertMatchesRegularExpression(
+            $expectedOutputRegex,
+            $writer->getOutput(),
+            'Output does not match expectation'
+        );
+        $this->assertSame($expectedExitcode, $exitCode, 'Exit code does not match expectation');
     }
 }

--- a/Tests/FeatureComplete/Check/CheckTestCase.php
+++ b/Tests/FeatureComplete/Check/CheckTestCase.php
@@ -22,30 +22,147 @@ abstract class CheckTestCase extends XTestCase
 {
 
     /**
-     * Run the actual test.
+     * Assert that the resulting output from a command to stdout matches a regular expression.
      *
-     * @param string $command             The command including arguments.
-     * @param string $expectedOutputRegex The regex against which the output should validate.
-     * @param int    $expectedExitcode    The expected exit code.
+     * @param string $command          The command including arguments.
+     * @param string $stdoutRegex      The regex against which the output should validate.
+     * @param int    $expectedExitcode The expected exit code.
      *
      * @return void
      */
-    protected function runValidation($command, $expectedOutputRegex, $expectedExitcode)
+    protected function assertStdoutMatches($command, $stdoutRegex, $expectedExitcode)
     {
         // Make the regex ignore differences in line endings.
-        $expectedOutputRegex = \preg_replace('`[\r\n]+`', '[\r\n]+', $expectedOutputRegex);
+        $stdoutRegex = $this->regexIgnoreEol($stdoutRegex);
+        $result      = $this->runValidation($command);
 
+        $this->assertMatchesRegularExpression(
+            $stdoutRegex,
+            $result['writer']->getStdout(),
+            'Stdout does not match expectation'
+        );
+        $this->assertSame($expectedExitcode, $result['exitCode'], 'Exit code does not match expectation');
+    }
+
+    /**
+     * Assert that the resulting output from a command to stderr matches a regular expression.
+     *
+     * @param string $command          The command including arguments.
+     * @param string $stderrRegex      The regex against which the output should validate.
+     * @param int    $expectedExitcode The expected exit code.
+     *
+     * @return void
+     */
+    protected function assertStderrMatches($command, $stderrRegex, $expectedExitcode)
+    {
+        // Make the regex ignore differences in line endings.
+        $stderrRegex = $this->regexIgnoreEol($stderrRegex);
+        $result      = $this->runValidation($command);
+
+        $this->assertMatchesRegularExpression(
+            $stderrRegex,
+            $result['writer']->getStderr(),
+            'Stderr does not match expectation'
+        );
+        $this->assertSame($expectedExitcode, $result['exitCode'], 'Exit code does not match expectation');
+    }
+
+    /**
+     * Assert that the resulting output from a command matches a regular expression.
+     *
+     * @param string $command          The command including arguments.
+     * @param string $outputRegex      The regex against which the output should validate.
+     * @param int    $expectedExitcode The expected exit code.
+     *
+     * @return void
+     */
+    protected function assertOutputMatches($command, $outputRegex, $expectedExitcode)
+    {
+        // Make the regex ignore differences in line endings.
+        $outputRegex = $this->regexIgnoreEol($outputRegex);
+        $result      = $this->runValidation($command);
+
+        $this->assertMatchesRegularExpression(
+            $outputRegex,
+            $result['writer']->getOutput(),
+            'Output does not match expectation'
+        );
+        $this->assertSame($expectedExitcode, $result['exitCode'], 'Exit code does not match expectation');
+    }
+
+    /**
+     * Assert that the resulting output from a command to stdout and stderr matches regular expressions.
+     *
+     * @param string $command          The command including arguments.
+     * @param string $stdoutRegex      The regex against which the stdout output should validate.
+     * @param string $stderrRegex      The regex against which the stderr output should validate.
+     * @param int    $expectedExitcode The expected exit code.
+     *
+     * @return void
+     */
+    protected function assertStdoutStdErrMatches($command, $stdoutRegex, $stderrRegex, $expectedExitcode)
+    {
+        // Make the regex ignore differences in line endings.
+        $stdoutRegex = $this->regexIgnoreEol($stdoutRegex);
+        $stderrRegex = $this->regexIgnoreEol($stderrRegex);
+        $result      = $this->runValidation($command);
+
+        $this->assertMatchesRegularExpression(
+            $stdoutRegex,
+            $result['writer']->getStdout(),
+            'Stdout does not match expectation'
+        );
+        $this->assertMatchesRegularExpression(
+            $stderrRegex,
+            $result['writer']->getStderr(),
+            'Stderr does not match expectation'
+        );
+        $this->assertSame($expectedExitcode, $result['exitCode'], 'Exit code does not match expectation');
+    }
+
+    /**
+     * Run the actual test.
+     *
+     * @param string $command The command including arguments.
+     *
+     * @return void
+     */
+    protected function runValidation($command)
+    {
         $_SERVER['argv'] = \explode(' ', $command);
         $writer          = new TestWriter();
         $config          = new Config($writer);
         $check           = new Check($config, $writer);
         $exitCode        = $check->validate();
 
-        $this->assertMatchesRegularExpression(
-            $expectedOutputRegex,
-            $writer->getOutput(),
-            'Output does not match expectation'
-        );
-        $this->assertSame($expectedExitcode, $exitCode, 'Exit code does not match expectation');
+        return [
+            'writer'   => $writer,
+            'exitCode' => $exitCode,
+        ];
+    }
+
+    /**
+     * Convert a regex containing hard-coded line endings to a regex which matches line endings
+     * independently of operating system.
+     *
+     * @param string $regex Regular expression.
+     *
+     * @return string
+     */
+    protected function regexIgnoreEol($regex)
+    {
+        return \preg_replace('`[\r\n]+`', '[\r\n]+', $regex);
+    }
+
+    /**
+     * Normalize line endings in an arbitrary text string to *nix line endings.
+     *
+     * @param string $text Arbitrary text string.
+     *
+     * @return string
+     */
+    protected function stringIgnoreEol($text)
+    {
+        return \str_replace(["\r\n", "\r"], "\n", $text);
     }
 }

--- a/Tests/FeatureComplete/Check/HasOrphansTest.php
+++ b/Tests/FeatureComplete/Check/HasOrphansTest.php
@@ -85,7 +85,7 @@ WARNING: Orphaned test file found          ' . $fixtureDirRegex . 'Tests[\\\\/]C
 -----------------------------------------
 Found 12 orphaned files\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -121,7 +121,7 @@ WARNING: Orphaned test file found          ' . $fixtureDir2Regex . 'Tests[\\\\/]
 -----------------------------------------
 Found 13 orphaned files\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -142,7 +142,7 @@ WARNING: Orphaned test file found          ' . $fixtureDirRegex . 'Tests[\\\\/]C
 -----------------------------------------
 Found 1 orphaned file\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -159,6 +159,6 @@ Found 1 orphaned file\.[\r\n]+$`';
 
 Found 1 sniff accompanied by unit tests.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 }

--- a/Tests/FeatureComplete/Check/MissingDocFilesTest.php
+++ b/Tests/FeatureComplete/Check/MissingDocFilesTest.php
@@ -73,7 +73,7 @@ WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryB[\\\\/]T
 ---------------------------------------
 Found 0 errors and 2 warnings\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -100,7 +100,7 @@ WARNING: Documentation missing for       ' . $sniffDir2Regex . 'CategoryA[\\\\/]
 ---------------------------------------
 Found 0 errors and 3 warnings\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -122,7 +122,7 @@ WARNING: Documentation missing for       ' . $sniffDirRegex . 'CategoryA[\\\\/]D
 ---------------------------------------
 Found 0 errors and 1 warning\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -139,6 +139,6 @@ Found 0 errors and 1 warning\.[\r\n]+$`';
 
 All 3 sniffs are accompanied by unit tests.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 }

--- a/Tests/FeatureComplete/Check/MissingTestFilesTest.php
+++ b/Tests/FeatureComplete/Check/MissingTestFilesTest.php
@@ -74,7 +74,7 @@ ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]T
 ---------------------------------------
 Found 3 errors and 0 warnings\.[\r\n]$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -102,7 +102,7 @@ ERROR:   Unit test case file missing for ' . $sniffDir2Regex . 'CategoryA[\\\\/]
 ---------------------------------------
 Found 4 errors and 0 warnings\.[\r\n]$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -124,7 +124,7 @@ ERROR:   Unit test case file missing for ' . $sniffDirRegex . 'CategoryA[\\\\/]D
 ---------------------------------------
 Found 1 error and 0 warnings\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -149,6 +149,6 @@ ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]T
 ---------------------------------------
 Found 3 errors\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 }

--- a/Tests/FeatureComplete/Check/MissingTestsAndDocsTest.php
+++ b/Tests/FeatureComplete/Check/MissingTestsAndDocsTest.php
@@ -76,7 +76,7 @@ ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]T
 ---------------------------------------
 Found 3 errors and 2 warnings\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -108,7 +108,7 @@ ERROR:   Unit tests missing for          ' . $sniffDir2Regex . 'CategoryA[\\\\/]
 ---------------------------------------
 Found 4 errors and 3 warnings\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -131,7 +131,7 @@ ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryA[\\\\/]D
 ---------------------------------------
 Found 1 error and 1 warning\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 
     /**
@@ -157,6 +157,6 @@ ERROR:   Unit tests missing for          ' . $sniffDirRegex . 'CategoryB[\\\\/]T
 ---------------------------------------
 Found 3 errors\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 1);
+        $this->assertOutputMatches($command, $regex, 1);
     }
 }

--- a/Tests/FeatureComplete/Check/NoSniffsTest.php
+++ b/Tests/FeatureComplete/Check/NoSniffsTest.php
@@ -69,7 +69,7 @@ No sniffs found\.
 Checking for orphaned files:
 No orphaned documentation or test files found\.[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 
     /**

--- a/Tests/FeatureComplete/Check/ValidStandardsTest.php
+++ b/Tests/FeatureComplete/Check/ValidStandardsTest.php
@@ -55,7 +55,7 @@ Checking for orphaned files:
 No orphaned documentation or test files found.';
         $regex          = '`' .  \preg_quote($expectedOutput, '`') . '[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 
     /**
@@ -110,7 +110,7 @@ Checking for orphaned files:
 No orphaned documentation or test files found.';
         $regex          = '`' .  \preg_quote($expectedOutput, '`') . '[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 
     /**
@@ -134,7 +134,7 @@ Checking for orphaned files:
 No orphaned documentation or test files found.';
         $regex          = '`' .  \preg_quote($expectedOutput, '`') . '[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 
     /**
@@ -154,7 +154,7 @@ No orphaned documentation or test files found.';
 All 3 sniffs are accompanied by unit tests.';
         $regex          = '`' .  \preg_quote($expectedOutput, '`') . '[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 
     /**
@@ -173,6 +173,6 @@ All 3 sniffs are accompanied by unit tests and documentation.
 No orphaned documentation or test files found.';
         $regex          = '`' .  \preg_quote($expectedOutput, '`') . '[\r\n]+$`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertOutputMatches($command, $regex, 0);
     }
 }

--- a/Tests/FeatureComplete/Check/VerboseTest.php
+++ b/Tests/FeatureComplete/Check/VerboseTest.php
@@ -49,7 +49,7 @@ Target dir\(s\):
 
 Checking sniff completeness:[\r\n]+`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertStderrMatches($command, $regex, 0);
     }
 
     /**
@@ -70,6 +70,6 @@ Target dir\(s\):
 
 Checking sniff completeness:[\r\n]+`';
 
-        $this->runValidation($command, $regex, 0);
+        $this->assertStderrMatches($command, $regex, 0);
     }
 }

--- a/Tests/FeatureComplete/Config/GetHelpTest.php
+++ b/Tests/FeatureComplete/Config/GetHelpTest.php
@@ -11,15 +11,16 @@
 namespace PHPCSDevTools\Tests\FeatureComplete\Config;
 
 use PHPCSDevTools\Scripts\FeatureComplete\Config;
-use PHPUnit\Framework\TestCase;
+use PHPCSDevTools\Tests\TestWriter;
 use ReflectionMethod;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
  * Test the "show help" feature.
  *
  * @covers \PHPCSDevTools\Scripts\FeatureComplete\Config::getHelp
  */
-final class GetHelpTest extends TestCase
+final class GetHelpTest extends XTestCase
 {
 
     /**
@@ -27,8 +28,7 @@ final class GetHelpTest extends TestCase
      *
      * @var string
      */
-    private $expectedOutputNoColors = '
-Usage:
+    private $expectedOutputNoColors = 'Usage:
   phpcs-check-feature-completeness
   phpcs-check-feature-completeness [-q] [--exclude=<dir>] [directories]
 
@@ -92,13 +92,14 @@ Options:
      */
     public function testShowHelpNoColors($command)
     {
-        $regex = '`' .  \preg_quote($this->expectedOutputNoColors, '`') . '`';
-        // Make the regex ignore differences in line endings.
-        $regex = \preg_replace('`[\r\n]+`', '[\r\n]+', $regex);
-        $this->expectOutputRegex($regex);
-
         $_SERVER['argv'] = \explode(' ', $command . ' --no-colors');
-        new Config();
+        $writer          = new TestWriter();
+        $config          = new Config($writer);
+
+        $actual = $writer->getStdout();
+        $actual = \str_replace(["\r\n", "\r"], "\n", $actual);
+
+        $this->assertStringContainsString($this->expectedOutputNoColors, $actual);
     }
 
     /**
@@ -126,7 +127,7 @@ Options:
     public function testGetHelpWithColors()
     {
         $_SERVER['argv'] = \explode(' ', 'command --colors');
-        $config          = new Config();
+        $config          = new Config(new TestWriter());
 
         $getHelp = new ReflectionMethod($config, 'getHelp');
         $getHelp->setAccessible(true);

--- a/Tests/FeatureComplete/Config/GetVersionTest.php
+++ b/Tests/FeatureComplete/Config/GetVersionTest.php
@@ -11,14 +11,15 @@
 namespace PHPCSDevTools\Tests\FeatureComplete\Config;
 
 use PHPCSDevTools\Scripts\FeatureComplete\Config;
-use PHPUnit\Framework\TestCase;
+use PHPCSDevTools\Tests\TestWriter;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
  * Test the "show version" feature.
  *
  * @covers \PHPCSDevTools\Scripts\FeatureComplete\Config::getVersion
  */
-final class GetVersionTest extends TestCase
+final class GetVersionTest extends XTestCase
 {
 
     /**
@@ -35,10 +36,12 @@ final class GetVersionTest extends TestCase
         $regex = '`^PHPCSDevTools: Sniff feature completeness checker version'
             . ' [0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}(?:-(?:alpha|beta|RC)\S+)?'
             . '[\r\n]+by Juliette Reinders Folmer[\r\n]*$`';
-        $this->expectOutputRegex($regex);
 
         $_SERVER['argv'] = \explode(' ', $command);
-        new Config();
+        $writer          = new TestWriter();
+        $config          = new Config($writer);
+
+        $this->assertMatchesRegularExpression($regex, $writer->getStdout());
     }
 
     /**

--- a/Tests/FeatureComplete/Config/MagicMethodsTest.php
+++ b/Tests/FeatureComplete/Config/MagicMethodsTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSDevTools\Tests\FeatureComplete\Config;
 
 use PHPCSDevTools\Scripts\FeatureComplete\Config;
+use PHPCSDevTools\Tests\TestWriter;
 use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
@@ -38,7 +39,7 @@ final class MagicMethodsTest extends XTestCase
     protected function setUpClass()
     {
         parent::setUp();
-        $this->config = new Config();
+        $this->config = new Config(new TestWriter());
     }
 
     /**
@@ -112,8 +113,12 @@ final class MagicMethodsTest extends XTestCase
                 'propertyName' => 'verbose',
                 'expected'     => true,
             ],
-            'property which exists on the class and access is not allowed' => [
+            'property which exists on the class and access is not allowed - helpTexts' => [
                 'propertyName' => 'helpTexts',
+                'expected'     => false,
+            ],
+            'property which exists on the class and access is not allowed - writer' => [
+                'propertyName' => 'writer',
                 'expected'     => false,
             ],
         ];

--- a/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
+++ b/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSDevTools\Tests\FeatureComplete\Config;
 
 use PHPCSDevTools\Scripts\FeatureComplete\Config;
+use PHPCSDevTools\Tests\TestWriter;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -59,7 +60,7 @@ final class ProcessCliCommandTest extends TestCase
         $expected['targetDirs']  = [$expected['projectRoot']];
 
         $_SERVER['argv'] = \explode(' ', $command);
-        $config          = new Config();
+        $config          = new Config(new TestWriter());
         $actual          = $this->getCurrentValues($config);
 
         unset($expected['showColored'], $actual['showColored']);
@@ -108,7 +109,7 @@ final class ProcessCliCommandTest extends TestCase
         $expected = \array_merge($this->defaultSettings, $expectedChanged);
 
         $_SERVER['argv'] = \explode(' ', $command);
-        $config          = new Config();
+        $config          = new Config(new TestWriter());
         $actual          = $this->getCurrentValues($config);
 
         if ($checkShowColored === false) {
@@ -379,11 +380,10 @@ final class ProcessCliCommandTest extends TestCase
      */
     public function testProcessCliCommandOutputOnlyArgs($command, $expectedChanged)
     {
-        $this->expectOutputRegex('`.*`s');
         $expected = \array_merge($this->defaultSettings, $expectedChanged);
 
         $_SERVER['argv'] = \explode(' ', $command);
-        $config          = new Config();
+        $config          = new Config(new TestWriter());
         $actual          = $this->getCurrentValues($config);
 
         unset($expected['showColored'], $actual['showColored']);

--- a/Tests/TestWriter.php
+++ b/Tests/TestWriter.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDevTools\Tests;
+
+use PHPCSDevTools\Scripts\Utils\Writer;
+
+/**
+ * Test Helper to catch text normally send to the command line.
+ *
+ * @since 2.0.0
+ */
+final class TestWriter implements Writer
+{
+
+    /**
+     * Text written to STDOUT during the test.
+     *
+     * @var string
+     */
+    private $stdout = '';
+
+    /**
+     * Text written to STDERR during the test.
+     *
+     * @var string
+     */
+    private $stderr = '';
+
+    /**
+     * All output as written during the test.
+     *
+     * @var string
+     */
+    private $output = '';
+
+    /**
+     * Catch output to STDOUT.
+     *
+     * @param string $text Output to send.
+     *
+     * @return void
+     */
+    public function toStdout($text)
+    {
+        $this->stdout .= $text;
+        $this->output .= $text;
+    }
+
+    /**
+     * Catch output to STDERR.
+     *
+     * @param string $text Output to send.
+     *
+     * @return void
+     */
+    public function toStderr($text)
+    {
+        $this->stderr .= $text;
+        $this->output .= $text;
+    }
+
+    /**
+     * Retrieve output send to STDOUT.
+     *
+     * @return string
+     */
+    public function getStdout()
+    {
+        return $this->stdout;
+    }
+
+    /**
+     * Retrieve output send to STDERR.
+     *
+     * @return string
+     */
+    public function getStderr()
+    {
+        return $this->stderr;
+    }
+
+    /**
+     * Retrieve all output send.
+     *
+     * @return string
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+}

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -52,11 +52,12 @@ foreach ($autoloadLocations as $file) {
     }
 }
 
-$config = new PHPCSDevTools\Scripts\FeatureComplete\Config();
+$writer = new PHPCSDevTools\Scripts\Utils\CliWriter();
+$config = new PHPCSDevTools\Scripts\FeatureComplete\Config($writer);
 if ($config->executeCheck === false) {
     // This was a help request or version check.
     exit(0);
 }
 
-$validate = new PHPCSDevTools\Scripts\FeatureComplete\Check($config);
+$validate = new PHPCSDevTools\Scripts\FeatureComplete\Check($config, $writer);
 exit($validate->validate());


### PR DESCRIPTION
### FeatureComplete/Utils: introduce Writer interface and CliWriter class

Together, these will allow for separating the data streams to `STDOUT` and `STDERR` as per industry best practices.

As PHPUnit uses `STDOUT` to write the test progress results, the `CliWriter` cannot be used during testing. With this in mind, the `CliWriter` class has been marked with `@codeCoverageIgnore` and a `TestWriter` class is introduced for use by the tests.

### FeatureComplete: implement use of the CliWriter class

This commit implements use of the `CliWriter` class to separate the information send to the screen.

Information send to `STDOUT`:
* The run results of the "feature complete" tool, i.e. errors, warnings and the scan summaries.
* Version information if specifically requested using the `-V` option.
* Help information if specifically requested using the `-h` option.

Information send to `STDERR`:
* The version information when shown as part of a scan run.
* Error messages, like "No sniffs found".
* Progress reporting.
* Verbose output.

Implementation notes:
* The `$writer` property in the `Config` class is made inaccessible from outside the class.
* The `CheckTestCase` and select other test classes, now use the PHPUnit Polyfills `XTestCase` as a parent class to allow access to allow polyfilled expectations and assertions, most notably, the `assertMatchesRegularExpression()` is now needed.
* All relevant tests now retrieve the generated output via the `TestWriter` instead of setting expectations for output to the screen via `expectOutputRegex()`.
    This also means that some of the tests can be simplified to use the `assertStringContainsString()` assertion instead of converting expected text to regular expressions. This will be (mostly) actioned in a follow-up commit.

### FeatureComplete: test more specifically for output in the correct stream

This commit:
* Adds four custom assertion methods to the `CheckTestCase` and two helper methods. The pre-existing `runValidation()` method is converted to _return_ the `Writer` instance and the exit code of the command for further processing.
* Adjusts various tests to test more specifically for the expected output being part of `STDOUT` or `STDERR` instead of just examining the complete output stream.
* Switching select tests over to using `assertStringContainsString()`/`assertStringEndsWith()` instead of `assertMatchesRegularExpression()`.
* Switches the remaining tests over to use one of the four new assertions.

Includes refactoring the test in the `MarkProgressTest` class to use a data provider.