### PR TITLE
PHPCSDebug/TokenList: visualize whitespace characters (take two)

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -12,6 +12,7 @@ namespace PHPCSDebug\Sniffs\Debug;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Lists how PHPCS tokenizes code.
@@ -114,6 +115,17 @@ final class TokenListSniff implements Sniff
                 if (isset($token['orig_content'])) {
                     $content .= $sep . 'Orig: ' . $this->visualizeWhitespace($token['orig_content']);
                 }
+            }
+
+            if (isset(Tokens::$commentTokens[$token['code']]) === true) {
+                /*
+                 * Comment tokens followed by a new line, will have trailing whitespace
+                 * included in the token, so visualize it.
+                 * For multi-line star comments (like this one), this also applies to leading whitespace.
+                 */
+                $comment    = \trim($content);
+                $whitespace = \str_replace($comment, '###', $content);
+                $content    = \str_replace('###', $comment, $this->visualizeWhitespace($whitespace));
             }
 
             $parenthesesCount = 0;


### PR DESCRIPTION
Follow up after PR #102.

Comment tokens, most notably `T_COMMENT` and `T_DOC_COMMENT_STRING` will have the new line character following it included in the token content.

This implies that potential _trailing whitespace_ (between the text and the new line character) will also be included in the token content.

In a similar vein as for _plain_ whitespace, this trailing whitespace should be visualized.

On top of that, for multi-line `/* */`-style comments, _leading_ whitespace will also be included in the token, so should also be visualized.

Again, this is primarily a change to improve usability, but it will also make testing this sniff easier as we no longer have to deal with trailing whitespace issues.