### PR TITLE
PHPCSDebug/TokenList: always show original content when available

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -106,18 +106,12 @@ final class TokenListSniff implements Sniff
                 }
             }
 
-            if ($token['code'] === \T_WHITESPACE
-                || (\defined('T_DOC_COMMENT_WHITESPACE')
-                && $token['code'] === \T_DOC_COMMENT_WHITESPACE)
-            ) {
+            if (isset($token['orig_content'])) {
+                $content  = $this->visualizeWhitespace($content);
+                $content .= $sep . 'Orig: ' . $this->visualizeWhitespace($token['orig_content']);
+            } elseif ($token['code'] === \T_WHITESPACE) {
                 $content = $this->visualizeWhitespace($content);
-
-                if (isset($token['orig_content'])) {
-                    $content .= $sep . 'Orig: ' . $this->visualizeWhitespace($token['orig_content']);
-                }
-            }
-
-            if (isset(Tokens::$commentTokens[$token['code']]) === true) {
+            } elseif (isset(Tokens::$commentTokens[$token['code']]) === true) {
                 /*
                  * Comment tokens followed by a new line, will have trailing whitespace
                  * included in the token, so visualize it.


### PR DESCRIPTION
When the `tab-width` configuration variable has been set for PHPCS - either via the config, via a ruleset or via the command-line -, PHPCS will replace tabs with spaces in the `'content'` and retain the original content in a `'orig_content'` key.

Previously, this "original content" would only be shown for whitespace tokens. However, tab replacement can also happen in other tokens. Typically tabs may also be found in text strings and comments contents.

This commit adjusts the sniff to _always_ show the "original content" if that array key has been set in the token array.
Whitespace visualization will be enabled in that case for both the `'content'` as well as the `'orig_content'` so the "tabs vs spaces" difference can be clearly seen.