### PR TITLE
PHPCSDebug/TokenList: bug fix - do not calculate token length

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -47,6 +47,7 @@ final class TokenListSniff implements Sniff
         'type'       => '?',
         'code'       => '?',
         'content'    => '',
+        'length'     => '?',
         'line'       => '?',
         'column'     => '?',
         'level'      => 0,
@@ -98,13 +99,6 @@ final class TokenListSniff implements Sniff
         foreach ($tokens as $ptr => $token) {
             $token  += $this->tokenDefaults;
             $content = $token['content'];
-
-            if (isset($token['length']) === false) {
-                $token['length'] = 0;
-                if (isset($token['content'])) {
-                    $token['length'] = \strlen($content);
-                }
-            }
 
             if (isset($token['orig_content'])) {
                 $content  = $this->visualizeWhitespace($content);


### PR DESCRIPTION
The output from the `TokenList` sniff should represent the information contained within the `$tokens` array.

While the information in the `$tokens` array may not be correct, the sniff should not try to "fix" it as that will misrepresent the real information contained in the `$tokens` array.

To this end:
* Ensure there is always a `'length'` key available by adding it to the `$tokenDefaults` array.
* Remove any manipulation of the value of the token `length` index.