### PR TITLE
PHPCSDebug/TokenList: expand and improve the tests

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -99,6 +99,7 @@ final class TokenListSniff implements Sniff
         foreach ($tokens as $ptr => $token) {
             $token  += $this->tokenDefaults;
             $content = $token['content'];
+            $onlyEol = false;
 
             if (isset($token['orig_content'])) {
                 $content  = $this->visualizeWhitespace($content);
@@ -121,13 +122,16 @@ final class TokenListSniff implements Sniff
                 $parenthesesCount = \count($token['nested_parenthesis']);
             }
 
+            $onlyEol = (\trim($content, "\n\r") === '');
+
             echo \str_pad($ptr, $ptrPadding, ' ', \STR_PAD_LEFT),
                 $sep, 'L', \str_pad($token['line'], $linePadding, '0', \STR_PAD_LEFT),
                 $sep, 'C', \str_pad($token['column'], 3, ' ', \STR_PAD_LEFT),
                 $sep, 'CC', \str_pad($token['level'], 2, ' ', \STR_PAD_LEFT),
                 $sep, '(', \str_pad($parenthesesCount, 2, ' ', \STR_PAD_LEFT), ')',
                 $sep, \str_pad($token['type'], 26), // Longest token type name is 26 chars.
-                $sep, '[', \str_pad($token['length'], 3, ' ', \STR_PAD_LEFT), ']: ', $content, \PHP_EOL;
+                $sep, '[', \str_pad($token['length'], 3, ' ', \STR_PAD_LEFT), ']:',
+                ($onlyEol === false ? ' ' : ''), $content, \PHP_EOL;
         }
 
         // Only do this once per file.

--- a/PHPCSDebug/Tests/Debug/TokenListCssTest.css
+++ b/PHPCSDebug/Tests/Debug/TokenListCssTest.css
@@ -1,0 +1,5 @@
+#id, .class_name {
+    color: #FFFFFF !important;
+    text-align: center;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.9);
+}

--- a/PHPCSDebug/Tests/Debug/TokenListCssTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListCssTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDebug\Tests\Debug;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Unit test class for the TokenList sniff.
+ *
+ * @covers \PHPCSDebug\Sniffs\Debug\TokenListSniff
+ *
+ * @since 1.0.0
+ */
+final class TokenListCssTest extends UtilityMethodTestCase
+{
+
+    /**
+     * The file extension of the test case file.
+     *
+     * @var string
+     */
+    protected static $fileExtension = 'css';
+
+    /**
+     * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
+     *
+     * @var array
+     */
+    protected static $selectedSniff = ['PHPCSDebug.Debug.TokenList'];
+
+    /**
+     * Test the actual output of the TokenList sniff.
+     *
+     * @return void
+     */
+    public function testOutput()
+    {
+        $expected = <<<'EOD'
+
+Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
+-------------------------------------------------------------------------
+  0 | L1 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  0]:
+  1 | L1 | C  1 | CC 0 | ( 0) | T_HASH                     | [  1]: #
+  2 | L1 | C  2 | CC 0 | ( 0) | T_STRING                   | [  2]: id
+  3 | L1 | C  4 | CC 0 | ( 0) | T_COMMA                    | [  1]: ,
+  4 | L1 | C  5 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+  5 | L1 | C  6 | CC 0 | ( 0) | T_STRING_CONCAT            | [  1]: .
+  6 | L1 | C  7 | CC 0 | ( 0) | T_STRING                   | [ 10]: class_name
+  7 | L1 | C 17 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+  8 | L1 | C 18 | CC 0 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
+  9 | L1 | C 19 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 10 | L2 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 11 | L2 | C  5 | CC 0 | ( 0) | T_STYLE                    | [  5]: color
+ 12 | L2 | C 10 | CC 0 | ( 0) | T_COLON                    | [  1]: :
+ 13 | L2 | C 11 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 14 | L2 | C 12 | CC 0 | ( 0) | T_COLOUR                   | [  7]: #FFFFFF
+ 15 | L2 | C 19 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 16 | L2 | C 20 | CC 0 | ( 0) | T_BOOLEAN_NOT              | [  1]: !
+ 17 | L2 | C 21 | CC 0 | ( 0) | T_STRING                   | [  9]: important
+ 18 | L2 | C 30 | CC 0 | ( 0) | T_SEMICOLON                | [  1]: ;
+ 19 | L2 | C 31 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 20 | L3 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 21 | L3 | C  5 | CC 0 | ( 0) | T_STYLE                    | [ 10]: text-align
+ 22 | L3 | C 15 | CC 0 | ( 0) | T_COLON                    | [  1]: :
+ 23 | L3 | C 16 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 24 | L3 | C 17 | CC 0 | ( 0) | T_STRING                   | [  6]: center
+ 25 | L3 | C 23 | CC 0 | ( 0) | T_SEMICOLON                | [  1]: ;
+ 26 | L3 | C 24 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 27 | L4 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 28 | L4 | C  5 | CC 0 | ( 0) | T_STYLE                    | [ 11]: text-shadow
+ 29 | L4 | C 16 | CC 0 | ( 0) | T_COLON                    | [  1]: :
+ 30 | L4 | C 17 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 31 | L4 | C 18 | CC 0 | ( 0) | T_LNUMBER                  | [  1]: 0
+ 32 | L4 | C 19 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 33 | L4 | C 20 | CC 0 | ( 0) | T_LNUMBER                  | [  1]: 1
+ 34 | L4 | C 21 | CC 0 | ( 0) | T_STRING                   | [  2]: px
+ 35 | L4 | C 23 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 36 | L4 | C 24 | CC 0 | ( 0) | T_LNUMBER                  | [  1]: 1
+ 37 | L4 | C 25 | CC 0 | ( 0) | T_STRING                   | [  2]: px
+ 38 | L4 | C 27 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 39 | L4 | C 28 | CC 0 | ( 0) | T_STRING                   | [  4]: rgba
+ 40 | L4 | C 32 | CC 0 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+ 41 | L4 | C 33 | CC 0 | ( 1) | T_LNUMBER                  | [  1]: 0
+ 42 | L4 | C 34 | CC 0 | ( 1) | T_COMMA                    | [  1]: ,
+ 43 | L4 | C 35 | CC 0 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 44 | L4 | C 36 | CC 0 | ( 1) | T_LNUMBER                  | [  1]: 0
+ 45 | L4 | C 37 | CC 0 | ( 1) | T_COMMA                    | [  1]: ,
+ 46 | L4 | C 38 | CC 0 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 47 | L4 | C 39 | CC 0 | ( 1) | T_LNUMBER                  | [  1]: 0
+ 48 | L4 | C 40 | CC 0 | ( 1) | T_COMMA                    | [  1]: ,
+ 49 | L4 | C 41 | CC 0 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 50 | L4 | C 42 | CC 0 | ( 1) | T_DNUMBER                  | [  3]: 0.9
+ 51 | L4 | C 45 | CC 0 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 52 | L4 | C 46 | CC 0 | ( 0) | T_SEMICOLON                | [  1]: ;
+ 53 | L4 | C 47 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 54 | L5 | C  1 | CC 0 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 55 | L5 | C  2 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 56 | L6 | C  1 | CC 0 | ( 0) | T_CLOSE_TAG                | [  0]:
+
+EOD;
+
+        $this->expectOutputString($expected);
+        $this->setOutputCallback([$this, 'normalizeLineEndings']);
+
+        self::$phpcsFile->process();
+    }
+
+    /**
+     * Callback function to normalize line endings in generated output.
+     *
+     * @param string $output The output as send to screen.
+     *
+     * @return string The output with *nix line endings.
+     */
+    public function normalizeLineEndings($output)
+    {
+        return \str_replace(["\r\n", "\r"], "\n", $output);
+    }
+}

--- a/PHPCSDebug/Tests/Debug/TokenListJsTest.js
+++ b/PHPCSDebug/Tests/Debug/TokenListJsTest.js
@@ -1,0 +1,8 @@
+jQuery(window).ready(function() {
+    spinner.addClass('is-active');
+    doSomething(function(response) {
+        if ('number' === typeof response && 1 === response) {
+            // Do something.
+        }
+    }, 'json');
+});

--- a/PHPCSDebug/Tests/Debug/TokenListJsTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListJsTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDebug\Tests\Debug;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Unit test class for the TokenList sniff.
+ *
+ * @covers \PHPCSDebug\Sniffs\Debug\TokenListSniff
+ *
+ * @since 1.0.0
+ */
+final class TokenListJsTest extends UtilityMethodTestCase
+{
+
+    /**
+     * The file extension of the test case file.
+     *
+     * @var string
+     */
+    protected static $fileExtension = 'js';
+
+    /**
+     * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
+     *
+     * @var array
+     */
+    protected static $selectedSniff = ['PHPCSDebug.Debug.TokenList'];
+
+    /**
+     * Test the actual output of the TokenList sniff.
+     *
+     * @return void
+     */
+    public function testOutput()
+    {
+        $expected = <<<'EOD'
+
+Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
+-------------------------------------------------------------------------
+  0 | L1 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  0]:
+  1 | L1 | C  1 | CC 0 | ( 0) | T_STRING                   | [  6]: jQuery
+  2 | L1 | C  7 | CC 0 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+  3 | L1 | C  8 | CC 0 | ( 1) | T_STRING                   | [  6]: window
+  4 | L1 | C 14 | CC 0 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+  5 | L1 | C 15 | CC 0 | ( 0) | T_OBJECT_OPERATOR          | [  1]: .
+  6 | L1 | C 16 | CC 0 | ( 0) | T_STRING                   | [  5]: ready
+  7 | L1 | C 21 | CC 0 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+  8 | L1 | C 22 | CC 0 | ( 1) | T_CLOSURE                  | [  8]: function
+  9 | L1 | C 30 | CC 0 | ( 1) | T_OPEN_PARENTHESIS         | [  1]: (
+ 10 | L1 | C 31 | CC 0 | ( 1) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 11 | L1 | C 32 | CC 0 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 12 | L1 | C 33 | CC 0 | ( 1) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 13 | L1 | C 34 | CC 1 | ( 1) | T_WHITESPACE               | [  0]:
+
+ 14 | L2 | C  1 | CC 1 | ( 1) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 15 | L2 | C  5 | CC 1 | ( 1) | T_STRING                   | [  7]: spinner
+ 16 | L2 | C 12 | CC 1 | ( 1) | T_OBJECT_OPERATOR          | [  1]: .
+ 17 | L2 | C 13 | CC 1 | ( 1) | T_STRING                   | [  8]: addClass
+ 18 | L2 | C 21 | CC 1 | ( 1) | T_OPEN_PARENTHESIS         | [  1]: (
+ 19 | L2 | C 22 | CC 1 | ( 2) | T_CONSTANT_ENCAPSED_STRING | [ 11]: 'is-active'
+ 20 | L2 | C 33 | CC 1 | ( 1) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 21 | L2 | C 34 | CC 1 | ( 1) | T_SEMICOLON                | [  1]: ;
+ 22 | L2 | C 35 | CC 1 | ( 1) | T_WHITESPACE               | [  0]:
+
+ 23 | L3 | C  1 | CC 1 | ( 1) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 24 | L3 | C  5 | CC 1 | ( 1) | T_STRING                   | [ 11]: doSomething
+ 25 | L3 | C 16 | CC 1 | ( 1) | T_OPEN_PARENTHESIS         | [  1]: (
+ 26 | L3 | C 17 | CC 1 | ( 2) | T_CLOSURE                  | [  8]: function
+ 27 | L3 | C 25 | CC 1 | ( 2) | T_OPEN_PARENTHESIS         | [  1]: (
+ 28 | L3 | C 26 | CC 1 | ( 3) | T_STRING                   | [  8]: response
+ 29 | L3 | C 34 | CC 1 | ( 2) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 30 | L3 | C 35 | CC 1 | ( 2) | T_WHITESPACE               | [  1]: ⸱
+ 31 | L3 | C 36 | CC 1 | ( 2) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 32 | L3 | C 37 | CC 2 | ( 2) | T_WHITESPACE               | [  0]:
+
+ 33 | L4 | C  1 | CC 2 | ( 2) | T_WHITESPACE               | [  8]: ⸱⸱⸱⸱⸱⸱⸱⸱
+ 34 | L4 | C  9 | CC 2 | ( 2) | T_IF                       | [  2]: if
+ 35 | L4 | C 11 | CC 2 | ( 2) | T_WHITESPACE               | [  1]: ⸱
+ 36 | L4 | C 12 | CC 2 | ( 2) | T_OPEN_PARENTHESIS         | [  1]: (
+ 37 | L4 | C 13 | CC 2 | ( 3) | T_CONSTANT_ENCAPSED_STRING | [  8]: 'number'
+ 38 | L4 | C 21 | CC 2 | ( 3) | T_WHITESPACE               | [  1]: ⸱
+ 39 | L4 | C 22 | CC 2 | ( 3) | T_IS_IDENTICAL             | [  3]: ===
+ 40 | L4 | C 25 | CC 2 | ( 3) | T_WHITESPACE               | [  1]: ⸱
+ 41 | L4 | C 26 | CC 2 | ( 3) | T_TYPEOF                   | [  6]: typeof
+ 42 | L4 | C 32 | CC 2 | ( 3) | T_WHITESPACE               | [  1]: ⸱
+ 43 | L4 | C 33 | CC 2 | ( 3) | T_STRING                   | [  8]: response
+ 44 | L4 | C 41 | CC 2 | ( 3) | T_WHITESPACE               | [  1]: ⸱
+ 45 | L4 | C 42 | CC 2 | ( 3) | T_BOOLEAN_AND              | [  2]: &&
+ 46 | L4 | C 44 | CC 2 | ( 3) | T_WHITESPACE               | [  1]: ⸱
+ 47 | L4 | C 45 | CC 2 | ( 3) | T_LNUMBER                  | [  1]: 1
+ 48 | L4 | C 46 | CC 2 | ( 3) | T_WHITESPACE               | [  1]: ⸱
+ 49 | L4 | C 47 | CC 2 | ( 3) | T_IS_IDENTICAL             | [  3]: ===
+ 50 | L4 | C 50 | CC 2 | ( 3) | T_WHITESPACE               | [  1]: ⸱
+ 51 | L4 | C 51 | CC 2 | ( 3) | T_STRING                   | [  8]: response
+ 52 | L4 | C 59 | CC 2 | ( 2) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 53 | L4 | C 60 | CC 2 | ( 2) | T_WHITESPACE               | [  1]: ⸱
+ 54 | L4 | C 61 | CC 2 | ( 2) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 55 | L4 | C 62 | CC 3 | ( 2) | T_WHITESPACE               | [  0]:
+
+ 56 | L5 | C  1 | CC 3 | ( 2) | T_WHITESPACE               | [ 12]: ⸱⸱⸱⸱⸱⸱⸱⸱⸱⸱⸱⸱
+ 57 | L5 | C 13 | CC 3 | ( 2) | T_COMMENT                  | [ 16]: // Do something.
+
+ 58 | L6 | C  1 | CC 3 | ( 2) | T_WHITESPACE               | [  8]: ⸱⸱⸱⸱⸱⸱⸱⸱
+ 59 | L6 | C  9 | CC 2 | ( 2) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 60 | L6 | C 10 | CC 2 | ( 2) | T_WHITESPACE               | [  0]:
+
+ 61 | L7 | C  1 | CC 2 | ( 2) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 62 | L7 | C  5 | CC 1 | ( 2) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 63 | L7 | C  6 | CC 1 | ( 2) | T_COMMA                    | [  1]: ,
+ 64 | L7 | C  7 | CC 1 | ( 2) | T_WHITESPACE               | [  1]: ⸱
+ 65 | L7 | C  8 | CC 1 | ( 2) | T_CONSTANT_ENCAPSED_STRING | [  6]: 'json'
+ 66 | L7 | C 14 | CC 1 | ( 1) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 67 | L7 | C 15 | CC 1 | ( 1) | T_SEMICOLON                | [  1]: ;
+ 68 | L7 | C 16 | CC 1 | ( 1) | T_WHITESPACE               | [  0]:
+
+ 69 | L8 | C  1 | CC 0 | ( 1) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 70 | L8 | C  2 | CC 0 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 71 | L8 | C  3 | CC 0 | ( 0) | T_SEMICOLON                | [  1]: ;
+ 72 | L8 | C  4 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 73 | L9 | C  1 | CC 0 | ( 0) | T_CLOSE_TAG                | [  0]:
+
+EOD;
+
+        $this->expectOutputString($expected);
+        $this->setOutputCallback([$this, 'normalizeLineEndings']);
+
+        self::$phpcsFile->process();
+    }
+
+    /**
+     * Callback function to normalize line endings in generated output.
+     *
+     * @param string $output The output as send to screen.
+     *
+     * @return string The output with *nix line endings.
+     */
+    public function normalizeLineEndings($output)
+    {
+        return \str_replace(["\r\n", "\r"], "\n", $output);
+    }
+}

--- a/PHPCSDebug/Tests/Debug/TokenListRegisterTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListRegisterTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCSDevTools, tools for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSDevTools
+ * @copyright 2019 PHPCSDevTools Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSDevTools
+ */
+
+namespace PHPCSDebug\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use PHPCSDebug\Sniffs\Debug\TokenListSniff;
+
+/**
+ * Unit test class for the TokenList sniff.
+ *
+ * @covers \PHPCSDebug\Sniffs\Debug\TokenListSniff::register
+ *
+ * @since 1.0.0
+ */
+final class TokenListRegisterTest extends TestCase
+{
+
+    /**
+     * Perfunctory test for the register method.
+     *
+     * @return void
+     */
+    public function testRegister()
+    {
+        $expected = [
+            \T_OPEN_TAG,
+            \T_OPEN_TAG_WITH_ECHO,
+        ];
+
+        $sniff = new TokenListSniff();
+        $this->assertSame($expected, $sniff->register());
+    }
+}

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.inc
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.inc
@@ -1,3 +1,10 @@
 <?php
 
-function
+/** Short Doc block. */
+function name($param) {
+	if ($condition === 'q	a' && $param === false) {
+        /* Do something.
+		 * Multi-line */
+    }
+    return $cl;
+}

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
@@ -15,7 +15,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 /**
  * Unit test class for the TokenList sniff.
  *
- * @covers PHPCSDebug\Sniffs\Debug\TokenListSniff
+ * @covers \PHPCSDebug\Sniffs\Debug\TokenListSniff
  *
  * @since 1.0.0
  */
@@ -36,13 +36,74 @@ final class TokenListUnitTest extends UtilityMethodTestCase
      */
     public function testOutput()
     {
-        $expected  = "\n";
-        $expected .= 'Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content' . "\n";
-        $expected .= '-------------------------------------------------------------------------' . "\n";
-        $expected .= '  0 | L1 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  5]: <?php' . "\n\n";
-        $expected .= '  1 | L2 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  0]: ' . "\n\n";
-        $expected .= '  2 | L3 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [  8]: function' . "\n";
-        $expected .= '  3 | L3 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [  0]: ' . "\n\n";
+        $expected = <<<'EOD'
+
+Ptr | Ln  | Col  | Cond | ( #) | Token Type                 | [len]: Content
+--------------------------------------------------------------------------
+  0 | L01 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  5]: <?php
+
+  1 | L02 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+  2 | L03 | C  1 | CC 0 | ( 0) | T_DOC_COMMENT_OPEN_TAG     | [  3]: /**
+  3 | L03 | C  4 | CC 0 | ( 0) | T_DOC_COMMENT_WHITESPACE   | [  1]: ⸱
+  4 | L03 | C  5 | CC 0 | ( 0) | T_DOC_COMMENT_STRING       | [ 17]: Short Doc block.⸱
+  5 | L03 | C 22 | CC 0 | ( 0) | T_DOC_COMMENT_CLOSE_TAG    | [  2]: */
+  6 | L03 | C 24 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+  7 | L04 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [  8]: function
+  8 | L04 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+  9 | L04 | C 10 | CC 0 | ( 0) | T_STRING                   | [  4]: name
+ 10 | L04 | C 14 | CC 0 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+ 11 | L04 | C 15 | CC 0 | ( 1) | T_VARIABLE                 | [  6]: $param
+ 12 | L04 | C 21 | CC 0 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 13 | L04 | C 22 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 14 | L04 | C 23 | CC 0 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 15 | L04 | C 24 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 16 | L05 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱ | Orig: →
+ 17 | L05 | C  5 | CC 1 | ( 0) | T_IF                       | [  2]: if
+ 18 | L05 | C  7 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 19 | L05 | C  8 | CC 1 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+ 20 | L05 | C  9 | CC 1 | ( 1) | T_VARIABLE                 | [ 10]: $condition
+ 21 | L05 | C 19 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 22 | L05 | C 20 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
+ 23 | L05 | C 23 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 24 | L05 | C 24 | CC 1 | ( 1) | T_CONSTANT_ENCAPSED_STRING | [  7]: 'q⸱⸱⸱a' | Orig: 'q→a'
+ 25 | L05 | C 31 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 26 | L05 | C 32 | CC 1 | ( 1) | T_BOOLEAN_AND              | [  2]: &&
+ 27 | L05 | C 34 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 28 | L05 | C 35 | CC 1 | ( 1) | T_VARIABLE                 | [  6]: $param
+ 29 | L05 | C 41 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 30 | L05 | C 42 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
+ 31 | L05 | C 45 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 32 | L05 | C 46 | CC 1 | ( 1) | T_FALSE                    | [  5]: false
+ 33 | L05 | C 51 | CC 1 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 34 | L05 | C 52 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 35 | L05 | C 53 | CC 1 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 36 | L05 | C 54 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 37 | L06 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  8]: ⸱⸱⸱⸱⸱⸱⸱⸱
+ 38 | L06 | C  9 | CC 2 | ( 0) | T_COMMENT                  | [ 16]: /* Do something.
+
+ 39 | L07 | C  1 | CC 2 | ( 0) | T_COMMENT                  | [ 24]: ⸱⸱⸱⸱⸱⸱⸱⸱⸱*⸱Multi-line⸱*/ | Orig: →→⸱*⸱Multi-line⸱*/
+ 40 | L07 | C 25 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 41 | L08 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 42 | L08 | C  5 | CC 1 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 43 | L08 | C  6 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 44 | L09 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 45 | L09 | C  5 | CC 1 | ( 0) | T_RETURN                   | [  6]: return
+ 46 | L09 | C 11 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 47 | L09 | C 12 | CC 1 | ( 0) | T_VARIABLE                 | [  3]: $cl
+ 48 | L09 | C 15 | CC 1 | ( 0) | T_SEMICOLON                | [  1]: ;
+ 49 | L09 | C 16 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 50 | L10 | C  1 | CC 0 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 51 | L10 | C  2 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+
+EOD;
 
         $this->expectOutputString($expected);
         $this->setOutputCallback([$this, 'normalizeLineEndings']);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
 
     <testsuites>
         <testsuite name="DebugSniff">
-            <directory suffix="UnitTest.php">./PHPCSDebug/Tests/</directory>
+            <directory suffix="Test.php">./PHPCSDebug/Tests/</directory>
         </testsuite>
         <testsuite name="DevTools">
             <directory suffix="Test.php">./Tests/FeatureComplete/</directory>


### PR DESCRIPTION
### PHPCSDebug/TokenList: minor tweak for testability

When a token only contains new line characters, a trailing space would be included on the line.

This makes testing the sniff harder as trailing whitespace is typically trimmed from a file, including in the expectations set in the tests.

This minor tweak ensures that the output for "new line only" tokens won't have trailing whitespace in the output line for the token.

### PHPCSDebug/TokenList: improve PHP test case file

... to include more code, allowing it to hit all conditions.

* Have code within parentheses - to verify the parentheses count display in the parentheses column.
* Have code within scope conditions - to verify the scope count display in the conditions column.
* Have a comment token which include trailing whitespace to verify visualization of this whitespace.
* Have a multi-line `/* */`-style comment to verify visualization of leading whitespace.
* Have `T_DOC_COMMENT_WHITESPACE` token to verify visualization of whitespace within docblocks.
* Have a tab in select places as a whitespace character to verify the correct display of `'content'` and `'orig_content'`, including whitespace visualization.
* Have a multi-digit number of lines in the test file to ensure the correct setting and padding of the "Line" column is safeguarded.

### PHPCSDebug/TokenList: add tests for CSS and JS

These tests safeguard that the sniff works just as well when given a CSS or JS file.

### PHPCSDebug/TokenList: add perfunctory test for the register() method