### PR TITLE
PHPCSDebug/TokenList: visualize whitespace in PHP 7.3+ heredoc/nowdoc closers

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -104,7 +104,10 @@ final class TokenListSniff implements Sniff
             if (isset($token['orig_content'])) {
                 $content  = $this->visualizeWhitespace($content);
                 $content .= $sep . 'Orig: ' . $this->visualizeWhitespace($token['orig_content']);
-            } elseif ($token['code'] === \T_WHITESPACE) {
+            } elseif ($token['code'] === \T_WHITESPACE
+                || $token['code'] === \T_END_HEREDOC
+                || $token['code'] === \T_END_NOWDOC
+            ) {
                 $content = $this->visualizeWhitespace($content);
             } elseif (isset(Tokens::$commentTokens[$token['code']]) === true) {
                 /*


### PR DESCRIPTION
Since PHP 7.3, heredoc/nowdoc closers may be indented.
This indent can use either tabs or spaces and the indent is included in the `T_END_HEREDOC`/`T_END_NOWDOC` token contents.

This commit adds whitespace visualization for these tokens.

No tests included as the tests would only work on PHP 7.3 and would break the pre-existing tests for PHP < 7.3 (due to the token stream being broken for flexible heredocs/nowdocs in PHP < 7.3).

Related: squizlabs/PHP_CodeSniffer#3639