### PR TITLE
Add "static analysis" and "dev" Composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name" : "phpcsstandards/phpcsdevtools",
     "description" : "Tools for PHP_CodeSniffer sniff developers.",
     "type" : "phpcodesniffer-standard",
-    "keywords" : [ "phpcs", "devtools", "debug", "php_codesniffer", "phpcodesniffer-standard" ],
+    "keywords" : [ "phpcs", "devtools", "debug", "dev", "static analysis", "php_codesniffer", "phpcodesniffer-standard" ],
     "homepage": "https://phpcsstandards.github.io/PHPCSDevTools/",
     "license" : "LGPL-3.0-or-later",
     "authors" : [


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "dev" and/or "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.

Both keywords were added in this repo since the package is more about supporting the development of PHPCS sniffs than the package predominantly providing sniffs itself.