### PR TITLE
GH Actions: various updates

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1
+      - uses: korelstar/xmllint-problem-matcher@v1.1
 
       # Validate the XSD and XML files against schema.
       - name: Validate Docs XSD against schema

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -49,9 +49,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,9 @@ jobs:
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -39,9 +39,9 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "::set-output name=BRANCH::$REF"
+            echo "BRANCH=$REF" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=BRANCH::stable'
+            echo 'BRANCH=stable' >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code
@@ -65,7 +65,7 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           shortsha=$(echo "$SHA" | cut -b 1-6)
-          echo "::set-output name=SHORTSHA::$shortsha"
+          echo "SHORTSHA=$shortsha" >> $GITHUB_OUTPUT
 
       - name: Prepare commit message
         id: commit_msg
@@ -74,9 +74,9 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           if [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'tag' ]]; then
-            echo "::set-output name=MSG::Update website for release of version $REF_NAME"
+            echo "MSG=Update website for release of version $REF_NAME" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=MSG::Sync website after commit (sha: ${{ steps.set_sha.outputs.SHORTSHA }})"
+            echo "MSG=Sync website after commit (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> $GITHUB_OUTPUT
           fi
 
       - name: Check GitHub Pages status


### PR DESCRIPTION
### GH Actions: fix use of deprecated set-output

GitHub has deprecated the use of `set-output` (and `set-state`) in favour of new environment files.

This commit updates workflows to use the new methodology.

Refs:
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

### GH Actions: update the xmllint-problem-matcher

The `xmllint-problem-matcher` action runner has released a new version which updates it to use node 16.
This gets rid of a warning which was shown in the action logs.

Refs:
* https://github.com/korelstar/xmllint-problem-matcher/releases/tag/v1.1