### PR TITLE
GH Actions: few tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1.1
+      - uses: korelstar/xmllint-problem-matcher@v1
 
       # Validate the XSD and XML files against schema.
       - name: Validate Docs XSD against schema

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -82,8 +82,9 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: composer checkcs -- --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml


### PR DESCRIPTION
### GH Actions/basics: revert to xmllint-problem-matcher v1

As the `korelstar/xmllint-problem-matcher` repo now has a long-running `v1` branch, this update which was included in PR #114 is no longer needed (and would necessitate more frequent updates if it would remain).

Ref:
* korelstar/xmllint-problem-matcher#7

### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.