### PR TITLE
GH Actions: various tweaks / PHP 8.2 not allowed to fail

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # @link http://xmlsoft.org/xmllint.html
       - name: Install xmllint

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors (PHP 7.2+)
         if: ${{ matrix.phpcs_version == 'dev-master' && matrix.php >= '7.2' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,8 @@ jobs:
         if: ${{ matrix.php < 8.2 }}
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow installation.
       - name: Install Composer dependencies - with ignore platform
@@ -116,7 +116,7 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors (PHP 7.2+)
         if: ${{ matrix.phpcs_version == 'dev-master' && matrix.php >= '7.2' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,17 @@ jobs:
         # - PHP 7.4 needs PHPCS 3.5.0+ to run without errors.
         # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
         # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
+        # - PHP 8.2 needs PHPCS 3.6.1+ to run without errors.
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2']
         phpcs_version: ['3.1.0', 'dev-master']
 
         include:
           # Complete the matrix, while preventing issues with PHPCS versions incompatible with certain PHP versions.
+          - php: '8.2'
+            phpcs_version: 'dev-master'
+          - php: '8.2'
+            phpcs_version: '3.6.1'
+
           - php: '8.1'
             phpcs_version: 'dev-master'
           - php: '8.1'
@@ -59,12 +65,12 @@ jobs:
           - php: '7.4'
             phpcs_version: '4.0.x-dev'
 
-          - php: '8.2' # Nightly.
+          - php: '8.3' # Nightly.
             phpcs_version: 'dev-master'
 
     name: "Test${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
-    continue-on-error: ${{ matrix.php == '8.2' || matrix.phpcs_version == '4.0.x-dev' }}
+    continue-on-error: ${{ matrix.php == '8.3' || matrix.phpcs_version == '4.0.x-dev' }}
 
     steps:
       - name: Checkout code
@@ -104,7 +110,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.2 }}
+        if: ${{ matrix.php < 8.3 }}
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -112,7 +118,7 @@ jobs:
 
       # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow installation.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.2 }}
+        if: ${{ matrix.php >= 8.3 }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: 'latest'
           ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: none
 


### PR DESCRIPTION
### GH Actions: use PHP latest

... for those tasks where the PHP version isn't that relevant.

### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: update PHP versions in workflows

PHP 8.2 has been released today 🎉 and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Note: PHPCS does not (yet) have full syntax support for PHP 8.2, but it does have runtime support (for the most part, see squizlabs/PHP_CodeSniffer#3629).

Builds against PHP 8.3 are still allowed to fail for now.