### PR TITLE
Composer: allow for the 1.0.0 version of the Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^3.1.0",
-        "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
+        "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {
         "roave/security-advisories" : "dev-master",


### PR DESCRIPTION
The Composer PHPCS plugin has released its 1.0.0 version. :tada:

Important:
I've _widened_ the version constraints for the plugin, instead of _bumping_ it.

The reason for this is to prevent conflicts with end-user projects/other external PHPCS standards which may also require(-dev) the plugin, but may not (yet) have updated _their_ constraints for the plugin. If the version would have been bumped instead of widened, those users would get an unsolvable conflict during the `composer install` run (unless they `require-dev` the plugin for the root project, but then, that's exactly what we _don't_ want them to do as external standards managing the versions of the plugins should  be more reliable).

The version constraints now set cover all released versions which support external standards properly.

Ref: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0