### PR TITLE
Add `security.md` file

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+The latest patch version of the `1.x` release series is supported for security updates.
+
+## Reporting a Vulnerability
+
+PHPCSDevTools is a developer tool and should generally not be used in a production (web accessible) environment.
+
+Having said that, responsible disclosure of security issues is highly appreciated.
+
+**Please do not report or discuss security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Issues can be reported privately to the maintainers by opening a [Security vulnerability report](https://github.com/PHPCSStandards/PHPCSDevTools/security/advisories/new).
+
+### Preferences
+
+* Please provide detailed reports with reproducible steps and a clearly defined impact.
+* Include the version number of the vulnerable package in your report.
+* Fixes are most welcome.
+    A private PR can be created from the security report to work on and discuss the patch.


### PR DESCRIPTION
... containing information about how to report security issues and what versions of PHPCompatibility are supported from a security point of view.

The file is placed in the `.github` directory. This will allow for it to be recognized correctly by GitHub, while not cluttering up the project root directory.

Ref: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository