### PR TITLE
Dependabot: target the "stable" branch for GHA PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    target-branch: "stable"
     commit-message:
       prefix: "GH Actions:"
     labels:


### PR DESCRIPTION
GitHub action runners should continue to work, both on the `stable` as well as the `develop` branch, so until 2.0 has been released, setting the Dependabot "target branch" to `stable`.