### PR TITLE
Switch to PHPCSStandards/PHP_CodeSniffer

### DIFF
--- a/PHPCSDebug/ruleset.xml
+++ b/PHPCSDebug/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDebug" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDebug" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <description>Sniffs which can be used as debugging tools for PHPCS developers</description>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ PHPCSDevTools for developers of PHP_CodeSniffer sniffs
 
 </div>
 
-This is a set of tools to assist developers of sniffs for [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+This is a set of tools to assist developers of sniffs for [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 
 * [Installation](#installation)
     + [Composer Project-based Installation](#composer-project-based-installation)
@@ -58,7 +58,7 @@ Composer will automatically install dependencies and register the PHPCSDebug sta
 
 ### Stand-alone Installation
 
-* Install [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
+* Install [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) via [your preferred method](https://github.com/PHPCSStandards/PHP_CodeSniffer#installation).
 * Register the path to PHPCS in your system `$PATH` environment variable to make the `phpcs` command available from anywhere in your file system.
 * Download the [latest PHPCSDevTools release](https://github.com/PHPCSStandards/PHPCSDevTools/releases) and unzip/untar it into an arbitrary directory.
     You can also choose to clone this repository using git.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
     <!--
     #############################################################################
     COMMAND LINE ARGUMENTS
-    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
     #############################################################################
     -->
 


### PR DESCRIPTION
⚠️  **_This is a DRAFT PR on purpose as it references releases which have not yet been tagged. Once the PHPCS 3.8.0 tag is available ~~(which contains the Composer `replace` directive)~~, this can/should be merged ASAP._** ⚠️ 

---

The Squizlabs repo has been abandoned. The project continues in a fork in the PHPCSStandards organisation.

Note: I'm not changing the version constraints. All tags since 2.0.0 have been recreated in the PHPCSStandards fork, though the package name in those tags has not been changed.

~~Based on tests I've run, the package should install fine when old tags are requested, though if a user has a `composer.json` which _also_ includes `squizlabs/php_codesniffer` in their dependency chain, this means that both will be installed, which could lead to issues.~~

~~I recommend tagging a release straight-away. This should then allow _our_ dependencies to update their own requirements and version constraints and to release, to prevent these type of problems.~~

**Update**: The Composer package name will not change, so while this PR should still be merged at our convenience (after the 3.8.0 release, expected this Friday), we will not need to do a release to unblock end-users.

Ref:
* squizlabs/PHP_CodeSniffer#3932