### PR TITLE
PHPCSDebug: fix tests

### DIFF
--- a/PHPCSDebug/Tests/Debug/TokenListCssTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListCssTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSDebug\Tests\Debug;
 
+use PHP_CodeSniffer\Util\Common;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -114,6 +115,17 @@ EOD;
 
         $this->expectOutputString($expected);
         $this->setOutputCallback([$this, 'normalizeLineEndings']);
+
+        if (empty($this->ruleset->tokenListeners)) {
+            // PHPCSUtils 1.0.9+.
+            $sniffFile      = \dirname(\dirname(__DIR__)) . \DIRECTORY_SEPARATOR . 'Sniffs';
+            $sniffFile     .= \DIRECTORY_SEPARATOR . 'Debug' . \DIRECTORY_SEPARATOR . 'TokenListSniff.php';
+            $sniffClassName = Common::cleanSniffClass('PHPCSDebug\\Sniffs\\Debug\\TokenListSniff');
+
+            $restrictions = [\strtolower($sniffClassName) => true];
+            self::$phpcsFile->ruleset->registerSniffs([$sniffFile], $restrictions, []);
+            self::$phpcsFile->ruleset->populateTokenListeners();
+        }
 
         self::$phpcsFile->process();
     }

--- a/PHPCSDebug/Tests/Debug/TokenListJsTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListJsTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSDebug\Tests\Debug;
 
+use PHP_CodeSniffer\Util\Common;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -134,6 +135,17 @@ EOD;
 
         $this->expectOutputString($expected);
         $this->setOutputCallback([$this, 'normalizeLineEndings']);
+
+        if (empty($this->ruleset->tokenListeners)) {
+            // PHPCSUtils 1.0.9+.
+            $sniffFile      = \dirname(\dirname(__DIR__)) . \DIRECTORY_SEPARATOR . 'Sniffs';
+            $sniffFile     .= \DIRECTORY_SEPARATOR . 'Debug' . \DIRECTORY_SEPARATOR . 'TokenListSniff.php';
+            $sniffClassName = Common::cleanSniffClass('PHPCSDebug\\Sniffs\\Debug\\TokenListSniff');
+
+            $restrictions = [\strtolower($sniffClassName) => true];
+            self::$phpcsFile->ruleset->registerSniffs([$sniffFile], $restrictions, []);
+            self::$phpcsFile->ruleset->populateTokenListeners();
+        }
 
         self::$phpcsFile->process();
     }

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSDebug\Tests\Debug;
 
+use PHP_CodeSniffer\Util\Common;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -107,6 +108,17 @@ EOD;
 
         $this->expectOutputString($expected);
         $this->setOutputCallback([$this, 'normalizeLineEndings']);
+
+        if (empty($this->ruleset->tokenListeners)) {
+            // PHPCSUtils 1.0.9+.
+            $sniffFile      = \dirname(\dirname(__DIR__)) . \DIRECTORY_SEPARATOR . 'Sniffs';
+            $sniffFile     .= \DIRECTORY_SEPARATOR . 'Debug' . \DIRECTORY_SEPARATOR . 'TokenListSniff.php';
+            $sniffClassName = Common::cleanSniffClass('PHPCSDebug\\Sniffs\\Debug\\TokenListSniff');
+
+            $restrictions = [\strtolower($sniffClassName) => true];
+            self::$phpcsFile->ruleset->registerSniffs([$sniffFile], $restrictions, []);
+            self::$phpcsFile->ruleset->populateTokenListeners();
+        }
 
         self::$phpcsFile->process();
     }

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -73,6 +73,11 @@ pointing to the PHPCS directory.
     die(1);
 }
 
+$installedStandards = \PHP_CodeSniffer\Util\Standards::getInstalledStandardDetails();
+foreach ($installedStandards as $details) {
+    \PHP_CodeSniffer\Autoload::addSearchPath($details['path'], $details['namespace']);
+}
+
 // Try and load the PHPCSUtils autoloader.
 if ($phpcsUtilsDir !== false && \file_exists($phpcsUtilsDir . $ds . 'phpcsutils-autoload.php')) {
     require_once $phpcsUtilsDir . $ds . 'phpcsutils-autoload.php';


### PR DESCRIPTION
PHPCSUtils 1.0.9 made a change to the `UtilityMethodTestCase` which causes the selected sniff to no longer register its token listeners as the `installed_paths` from the `CodeSniffer.conf` file are no longer read out.

While this is fine for actual utility methods, it breaks the tests for the `PHPCSDebug.Debug.TokenList` test.

Fixed now.

Refs:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.9
* https://github.com/PHPCSStandards/PHPCSUtils/pull/525