### PR TITLE
DocsXsdTest: fix test

### DIFF
--- a/Tests/DocsXsd/DocsXsdTest.php
+++ b/Tests/DocsXsd/DocsXsdTest.php
@@ -141,7 +141,7 @@ final class DocsXsdTest extends IOTestCase
             'More than two code blocks in one comparison group' => [
                 'fixtureFile'    => 'InvalidMoreThanTwoCodeBlocksInComparison.xml',
                 'expectedStdOut' => '',
-                'expectedStdErr' => "Schemas validity error : Element 'code': This element is not expected.",
+                'expectedStdErr' => "Element 'code': This element is not expected.",
             ],
             'Less than two code blocks in one comparison group' => [
                 'fixtureFile'    => 'InvalidLessThanTwoCodeBlocksInComparison.xml',


### PR DESCRIPTION
The "Schemas validity error :" phrase may not always show (and is not essential for the test anyhow).