### PR TITLE
Debug/TokenList: simplify skipping the rest of the file

### DIFF
--- a/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
+++ b/PHPCSDebug/Sniffs/Debug/TokenListSniff.php
@@ -139,7 +139,7 @@ class TokenListSniff implements Sniff
         }
 
         // Only do this once per file.
-        return ($phpcsFile->numTokens + 1);
+        return $phpcsFile->numTokens;
     }
 
     /**


### PR DESCRIPTION
This commit updates the sniff to use `return $phpcsFile->numTokens` instead of `return ($phpcsFile->numTokens + 1)`.

If a sniff file contains 50 tokens, the last `$stackPtr` will be 49, so returning `50` will already get us passed the end of the token stack and the `+ 1` is redundant.