### PR TITLE
Tests: make dataproviders static

### DIFF
--- a/Tests/DocsXsd/DocsXsdTest.php
+++ b/Tests/DocsXsd/DocsXsdTest.php
@@ -60,7 +60,7 @@ final class DocsXsdTest extends IOTestCase
      *
      * @return array<string, array<string, string>>
      */
-    public function dataValidXsd()
+    public static function dataValidXsd()
     {
         return [
             'Valid docs example with single standard in the file' => [
@@ -110,7 +110,7 @@ final class DocsXsdTest extends IOTestCase
      *
      * @return array<string, array<string, string>>
      */
-    public function dataInvalidXsd()
+    public static function dataInvalidXsd()
     {
         return [
             'Title attribute too long on <documentation> element' => [


### PR DESCRIPTION
As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

Refs:
* sebastianbergmann/phpunit@9caafe2
* sebastianbergmann/phpunit#5100