### PR TITLE
Tests: allow for running on PHPUnit 10/11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 /phpcs.xml.dist        export-ignore
 /phpstan.neon.dist     export-ignore
 /phpunit.xml.dist      export-ignore
+/phpunitlte9.xml.dist  export-ignore
 /phpunit-bootstrap.php export-ignore
 /PHPCSDebug/Tests      export-ignore
 /Tests                 export-ignore

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -96,9 +96,22 @@ jobs:
         if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer check-complete
 
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: Determine PHPUnit composer script to use
+        id: phpunit_script
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) || startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'SUFFIX=' >> $GITHUB_OUTPUT
+          else
+            echo 'SUFFIX=-lte9' >> $GITHUB_OUTPUT
+          fi
+
       - name: Run the unit tests for the PHPCSDebug sniff
-        run: composer test-sniff
+        run: composer test-sniff${{ steps.phpunit_script.outputs.SUFFIX }}
 
       - name: Run the unit tests for the DevTools
         if: ${{ matrix.phpcs_version == 'dev-master' }}
-        run: composer test-tools
+        run: composer test-tools${{ steps.phpunit_script.outputs.SUFFIX }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,9 +150,22 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer check-complete
 
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: Determine PHPUnit composer script to use
+        id: phpunit_script
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) || startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'SUFFIX=' >> $GITHUB_OUTPUT
+          else
+            echo 'SUFFIX=-lte9' >> $GITHUB_OUTPUT
+          fi
+
       - name: Run the unit tests for the PHPCSDebug sniff
-        run: composer test-sniff
+        run: composer test-sniff${{ steps.phpunit_script.outputs.SUFFIX }}
 
       - name: Run the unit tests for the DevTools
         if: ${{ matrix.phpcs_version == 'dev-master' }}
-        run: composer test-tools
+        run: composer test-tools${{ steps.phpunit_script.outputs.SUFFIX }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+build/
 deploy/
 vendor/
 composer.lock
 .phpcs.xml
 phpcs.xml
 phpunit.xml
+phpunitlte9.xml
 .phpunit.result.cache
 phpstan.neon

--- a/PHPCSDebug/Tests/Debug/TokenListCssTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListCssTest.php
@@ -113,9 +113,6 @@ Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
 
 EOD;
 
-        $this->expectOutputString($expected);
-        $this->setOutputCallback([$this, 'normalizeLineEndings']);
-
         if (empty(self::$phpcsFile->ruleset->tokenListeners)) {
             // PHPCSUtils 1.0.9+.
             $sniffFile      = \dirname(\dirname(__DIR__)) . \DIRECTORY_SEPARATOR . 'Sniffs';
@@ -127,7 +124,13 @@ EOD;
             self::$phpcsFile->ruleset->populateTokenListeners();
         }
 
+        \ob_start();
         self::$phpcsFile->process();
+
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        $this->assertSame($expected, $this->normalizeLineEndings($output));
     }
 
     /**

--- a/PHPCSDebug/Tests/Debug/TokenListJsTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListJsTest.php
@@ -133,9 +133,6 @@ Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
 
 EOD;
 
-        $this->expectOutputString($expected);
-        $this->setOutputCallback([$this, 'normalizeLineEndings']);
-
         if (empty(self::$phpcsFile->ruleset->tokenListeners)) {
             // PHPCSUtils 1.0.9+.
             $sniffFile      = \dirname(\dirname(__DIR__)) . \DIRECTORY_SEPARATOR . 'Sniffs';
@@ -147,7 +144,13 @@ EOD;
             self::$phpcsFile->ruleset->populateTokenListeners();
         }
 
+        \ob_start();
         self::$phpcsFile->process();
+
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        $this->assertSame($expected, $this->normalizeLineEndings($output));
     }
 
     /**

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
@@ -106,9 +106,6 @@ Ptr | Ln  | Col  | Cond | ( #) | Token Type                 | [len]: Content
 
 EOD;
 
-        $this->expectOutputString($expected);
-        $this->setOutputCallback([$this, 'normalizeLineEndings']);
-
         if (empty(self::$phpcsFile->ruleset->tokenListeners)) {
             // PHPCSUtils 1.0.9+.
             $sniffFile      = \dirname(\dirname(__DIR__)) . \DIRECTORY_SEPARATOR . 'Sniffs';
@@ -120,7 +117,13 @@ EOD;
             self::$phpcsFile->ruleset->populateTokenListeners();
         }
 
+        \ob_start();
         self::$phpcsFile->process();
+
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        $this->assertSame($expected, $this->normalizeLineEndings($output));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     },
     "require-dev" : {
         "roave/security-advisories" : "dev-master",
-        "phpunit/phpunit" : "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit" : "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "php-parallel-lint/php-console-highlighter": "^1.0.0",
         "phpcsstandards/phpcsdevcs": "^1.1.6",
         "phpcsstandards/phpcsutils" : "^1.0",
-        "yoast/phpunit-polyfills": "^1.1"
+        "yoast/phpunit-polyfills": "^1.1 || ^2.0 || ^3.0"
     },
     "config": {
         "allow-plugins": {
@@ -72,6 +72,15 @@
         ],
         "test-tools": [
             "@php ./vendor/phpunit/phpunit/phpunit --testsuite DevTools"
+        ],
+        "test-lte9": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunitlte9.xml.dist"
+        ],
+        "test-sniff-lte9": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunitlte9.xml.dist --testsuite DebugSniff"
+        ],
+        "test-tools-lte9": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunitlte9.xml.dist --testsuite DevTools"
         ],
         "check-complete": [
             "@php ./bin/phpcs-check-feature-completeness ./PHPCSDebug"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-    backupGlobals="true"
-    bootstrap="./phpunit-bootstrap.php"
-    beStrictAboutTestsThatDoNotTestAnything="false"
-    convertErrorsToExceptions="true"
-    convertWarningsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertDeprecationsToExceptions="true"
-    colors="true"
-    forceCoversAnnotation="true">
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+        backupGlobals="true"
+        bootstrap="./phpunit-bootstrap.php"
+        beStrictAboutTestsThatDoNotTestAnything="false"
+        cacheDirectory="build/phpunit-cache"
+        colors="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnIncompleteTests="true"
+        displayDetailsOnSkippedTests="true"
+        displayDetailsOnPhpunitDeprecations="false"
+        failOnWarning="true"
+        failOnNotice="true"
+        failOnDeprecation="true"
+        failOnPhpunitDeprecation="false"
+        requireCoverageMetadata="true"
+    >
 
     <testsuites>
         <testsuite name="DebugSniff">

--- a/phpunitlte9.xml.dist
+++ b/phpunitlte9.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="./phpunit-bootstrap.php"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertDeprecationsToExceptions="true"
+    colors="true"
+    forceCoversAnnotation="true">
+
+    <testsuites>
+        <testsuite name="DebugSniff">
+            <directory suffix="Test.php">./PHPCSDebug/Tests/</directory>
+        </testsuite>
+        <testsuite name="DevTools">
+            <directory suffix="Test.php">./Tests/DocsXsd/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
### Tests/HasNewLineSupportTest: work round removal of the `setOutputCallback()` method

PHPUnit 10.0 removed the `TestCase::setOutputCallback()` method without replacement.

Refs:
* sebastianbergmann/phpunit#5319

### Tests: allow for running on PHPUnit 10/11

Until now, the tests would run on PHPUnit 9 for PHP 7.3 and higher.

PHPUnit 10 (PHP 8.1+) was released in February 2023, PHPUnit 11 (PHP 8.2+) in February 2024 and the update for this test suite is quite painless, so let's allow for running the tests on PHPUnit 10 and 11 (with PHPUnit Polyfills 2.x/3.x).

This commit actions this.

Things to be aware of:

#### Handling of PHPUnit deprecations

Prior to PHPUnit 10.5.32 and PHPUnit 11.3.3, if the `failOnDeprecation` attribute was set (previously: `convertDeprecationsToExceptions`), tests runs would not only fail on PHP deprecation notices, but also on PHPUnit native deprecation notices when running on PHPUnit 10/11.

This undesirable behaviour has now (finally) been reverted, which makes updating test suites for compatibility with PHPUnit 10/11 a lot more straight-forward.

This is the reason that the minimum PHPUnit 10/11 versions in the `composer.json` file are set to such specific versions.

As part of this change, PHPUnit 10.5.32 and 11.3.3 introduce two new options for both the configuration file and as CLI arguments: `displayDetailsOnPhpunitDeprecations` and `failOnPhpunitDeprecation`, both of which will default to `false`.

These options have been added to the PHPUnit configuration for PHPUnit 10/11 to safeguard them against changes in the default value.

#### Test configuration file changes

The configuration file specification has undergone changes in PHPUnit 9.3, 10.0 and 10.1.

Most notably:
* In PHPUnit 9.3, the manner of specifying the code coverage configuration has changed.
* In PHPUnit 10.0, a significant number of attributes of the `<phpunit>` element were removed or renamed.
* In PHPUnit 10.1, the manner for specifying the code coverage configuration was changed again.

While the `--migrate-configuration` command can upgrade a configuration for the changes in the format made in PHPUnit 9.3 and 10.1, some of the changes in the configuration format in PHPUnit 10 don't have one-on-one replacements and/or are not taken into account.

With that in mind, I deem it more appropriate to have a dedicated PHPUnit configuration file for PHPUnit 10+ to ensure the test run will behave as intended.

To that end:
* The `phpunit.xml.dist` file has been renamed to `phpunitlte9.xml.dist` (for PHPUnit <= 9) and a new `phpunit.xml.dist` file has been added for PHPUnit 10+.
* The renamed file is set to be excluded from release archives via `.gitattributes` and a potential local overload file for it is set to be ignored by default via the `.gitignore` file.
* Additional scripts have been added to the `composer.json` file to run the tests either with the new or the old configuration file.
* The GH Actions `test` workflow has been updated to select the correct configuration file based on the PHPUnit version on which the tests are being run.

#### Other command/config changes

Also note that the `--coverage-cache <dir>` CLI flag was deprecated in PHPUnit 10 and removed in PHPUnit 11. A generic `cacheDirectory` attribute is the recommended replacement (though a CLI option is also available).
The new attribute has been added to the PHPUnit 10+ config file and the directory it points to has been added to `.gitignore`.

Ref:
* https://phpunit.de/announcements/phpunit-11.html
* https://phpunit.de/announcements/phpunit-10.html