### PR TITLE
GH Actions/PHPStan: use reusable workflow

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -99,28 +99,4 @@ jobs:
         run: cs2pr ./phpcs-report.xml
 
   phpstan:
-    name: "PHPStan"
-    runs-on: "ubuntu-latest"
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 'latest'
-          coverage: none
-          tools: phpstan
-
-      # Install dependencies and handle caching in one go.
-      # Dependencies need to be installed to make sure the PHPCS and PHPUnit classes are recognized.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v3"
-        with:
-          # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      - name: Run PHPStan
-        run: phpstan analyse
+    uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main


### PR DESCRIPTION
A number of reusable workflows have been introduced in the `PHPCSStandards/.github` repository for workflows used in multiple repos in this organisation, for which the steps are basically the same everywhere.

This will make maintenance of these workflows more straight-forward.

This commit switches the PHPStan workflow over to start using the reusable workflow.