### PR TITLE
GH Actions: always quote variables

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -54,9 +54,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP
@@ -98,15 +98,15 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Determine PHPUnit composer script to use
         id: phpunit_script
         run: |
           if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) || startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
-            echo 'SUFFIX=' >> $GITHUB_OUTPUT
+            echo 'SUFFIX=' >> "$GITHUB_OUTPUT"
           else
-            echo 'SUFFIX=-lte9' >> $GITHUB_OUTPUT
+            echo 'SUFFIX=-lte9' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run the unit tests for the PHPCSDebug sniff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,9 @@ jobs:
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP
@@ -152,15 +152,15 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Determine PHPUnit composer script to use
         id: phpunit_script
         run: |
           if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) || startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
-            echo 'SUFFIX=' >> $GITHUB_OUTPUT
+            echo 'SUFFIX=' >> "$GITHUB_OUTPUT"
           else
-            echo 'SUFFIX=-lte9' >> $GITHUB_OUTPUT
+            echo 'SUFFIX=-lte9' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run the unit tests for the PHPCSDebug sniff

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -42,9 +42,9 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "BRANCH=$REF" >> $GITHUB_OUTPUT
+            echo "BRANCH=$REF" >> "$GITHUB_OUTPUT"
           else
-            echo 'BRANCH=stable' >> $GITHUB_OUTPUT
+            echo 'BRANCH=stable' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout code
@@ -68,7 +68,7 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           shortsha=$(echo "$SHA" | cut -b 1-6)
-          echo "SHORTSHA=$shortsha" >> $GITHUB_OUTPUT
+          echo "SHORTSHA=$shortsha" >> "$GITHUB_OUTPUT"
 
       - name: Prepare commit message
         id: commit_msg
@@ -77,9 +77,9 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           if [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'tag' ]]; then
-            echo "MSG=Update website for release of version $REF_NAME" >> $GITHUB_OUTPUT
+            echo "MSG=Update website for release of version $REF_NAME" >> "$GITHUB_OUTPUT"
           else
-            echo "MSG=Sync website after commit (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> $GITHUB_OUTPUT
+            echo "MSG=Sync website after commit (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check GitHub Pages status


### PR DESCRIPTION
... to satisfy shellcheck rule SC2086: "Double quote to prevent globbing and word splitting".

Ref: https://www.shellcheck.net/wiki/SC2086