### PR TITLE
FileList: improve doc specificity

### DIFF
--- a/Scripts/FileList.php
+++ b/Scripts/FileList.php
@@ -47,7 +47,7 @@ class FileList
     /**
      * Regex iterator.
      *
-     * @var \RegexIterator
+     * @var \RegexIterator<mixed, mixed, \Traversable<mixed, mixed>>
      */
     protected $fileIterator;
 
@@ -85,7 +85,7 @@ class FileList
     /**
      * Retrieve the filtered file list iterator.
      *
-     * @return \RegexIterator
+     * @return \RegexIterator<mixed, mixed, \Traversable<mixed, mixed>>
      */
     public function getIterator()
     {


### PR DESCRIPTION
Make the iterator list type specifications more specific to comply with expectations in PHPStan 2.0.

Note: in reality the type should be `\RegexIterator<int, string, \Traversable<int, string>>`, but would yield yet another PHPStan error, so let's just leave it like this for now.