### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,17 @@ jobs:
         # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
         # - PHP 8.2 needs PHPCS 3.6.1+ to run without errors.
         # - PHP 8.3 needs PHPCS 3.8.0+ to run without errors (though the errors don't affect this package).
+        # - PHP 8.4 needs PHPCS 3.8.0+ to run without errors (officially 3.11.0, but 3.8.0 will work fine).
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2']
         phpcs_version: ['3.1.0', 'dev-master']
 
         include:
           # Complete the matrix, while preventing issues with PHPCS versions incompatible with certain PHP versions.
+          - php: '8.4'
+            phpcs_version: 'dev-master'
+          - php: '8.4'
+            phpcs_version: '3.8.0'
+
           - php: '8.3'
             phpcs_version: 'dev-master'
           - php: '8.3'
@@ -71,12 +77,12 @@ jobs:
           - php: '7.4'
             phpcs_version: '4.0.x-dev'
 
-          - php: '8.4' # Nightly.
+          - php: '8.5' # Nightly.
             phpcs_version: 'dev-master'
 
     name: "Test${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
-    continue-on-error: ${{ matrix.php == '8.4' || matrix.phpcs_version == '4.0.x-dev' }}
+    continue-on-error: ${{ matrix.php == '8.5' || matrix.phpcs_version == '4.0.x-dev' }}
 
     steps:
       - name: Checkout code
@@ -121,7 +127,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.4 }}
+        if: ${{ matrix.php < 8.5 }}
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -129,7 +135,7 @@ jobs:
 
       # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow installation.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.4 }}
+        if: ${{ matrix.php >= 8.5 }}
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-reqs

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PHPCSDevTools for developers of PHP_CodeSniffer sniffs
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/phpcsdevtools.svg?maxAge=3600)](https://packagist.org/packages/phpcsstandards/phpcsdevtools)
 [![Build Status CS](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/cs.yml/badge.svg)](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/cs.yml)
 [![Build Status Test](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/test.yml/badge.svg)](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/test.yml)
-[![Tested on PHP 5.4 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://github.com/PHPCSStandards/PHPCSDevTools/actions?query=workflow%3ATest)
+[![Tested on PHP 5.4 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://github.com/PHPCSStandards/PHPCSDevTools/actions?query=workflow%3ATest)
 
 [![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsdevtools/license)](https://github.com/PHPCSStandards/PHPCSDevTools/blob/stable/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.5.
* Update the "tested against" badge in the README.

Ref: https://www.php.net/releases/8.4/en.php