### PR TITLE
GH Actions: use the xmllint-validate action runner and enhance checks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -19,9 +19,6 @@ jobs:
     name: 'Basic CS and QA checks'
     runs-on: ubuntu-latest
 
-    env:
-      XMLLINT_INDENT: '    '
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -82,13 +79,6 @@ jobs:
       - name: Validate docs against schema
         run: xmllint --noout --schema DocsXsd/phpcsdocs.xsd ./PHPCSDebug/Docs/*/*Standard.xml
 
-      # Check code-style consistency of the XSD and XML files.
-      - name: Check XSD code style
-        run: diff -B ./DocsXsd/phpcsdocs.xsd <(xmllint --format "./DocsXsd/phpcsdocs.xsd")
-
-      - name: Check Ruleset XML code style
-        run: diff -B ./PHPCSDebug/ruleset.xml <(xmllint --format "./PHPCSDebug/ruleset.xml")
-
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
         id: phpcs
@@ -97,6 +87,38 @@ jobs:
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml
+
+  xml-cs:
+    name: 'XML Code style'
+    runs-on: ubuntu-latest
+
+    env:
+      XMLLINT_INDENT: '    '
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+      # This should not be blocking for this job, so ignore any errors from this step.
+      # Ref: https://github.com/dotnet/core/issues/4167
+      - name: Update the available packages list
+        continue-on-error: true
+        run: sudo apt-get update
+
+      - name: Install xmllint
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      # Show XML violations inline in the file diff.
+      - name: Enable showing XML issues inline
+        uses: korelstar/xmllint-problem-matcher@v1
+
+      # Check code-style consistency of the XSD and XML files.
+      - name: Check XSD code style
+        run: diff -B ./DocsXsd/phpcsdocs.xsd <(xmllint --format "./DocsXsd/phpcsdocs.xsd")
+
+      - name: Check Ruleset XML code style
+        run: diff -B ./PHPCSDebug/ruleset.xml <(xmllint --format "./PHPCSDebug/ruleset.xml")
 
   phpstan:
     uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -50,34 +50,24 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
-      # This should not be blocking for this job, so ignore any errors from this step.
-      # Ref: https://github.com/dotnet/core/issues/4167
-      - name: Update the available packages list
-        continue-on-error: true
-        run: sudo apt-get update
-
-      # @link http://xmlsoft.org/xmllint.html
-      - name: Install xmllint
-        run: sudo apt-get install --no-install-recommends -y libxml2-utils
-
-      - name: Download the XSD schema
-        run: curl http://www.w3.org/2001/XMLSchema.xsd --output XMLSchema.xsd
-
-      # Show XML violations inline in the file diff.
-      # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - name: Enable showing XML issues inline
-        uses: korelstar/xmllint-problem-matcher@v1
-
       # Validate the XSD and XML files against schema.
       - name: Validate Docs XSD against schema
-        run: xmllint --noout --schema XMLSchema.xsd DocsXsd/phpcsdocs.xsd
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "DocsXsd/phpcsdocs.xsd"
+          xsd-url: "https://www.w3.org/2012/04/XMLSchema.xsd"
 
       - name: Validate PHPCSDebug ruleset against schema
-        run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd PHPCSDebug/ruleset.xml
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "PHPCSDebug/ruleset.xml"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
 
       - name: Validate docs against schema
-        run: xmllint --noout --schema DocsXsd/phpcsdocs.xsd ./PHPCSDebug/Docs/*/*Standard.xml
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "PHPCSDebug/Docs/*/*Standard.xml"
+          xsd-file: "DocsXsd/phpcsdocs.xsd"
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -69,6 +69,36 @@ jobs:
           pattern: "PHPCSDebug/Docs/*/*Standard.xml"
           xsd-file: "DocsXsd/phpcsdocs.xsd"
 
+      - name: Validate Project PHPCS ruleset against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpcs.xml.dist"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
+
+      - name: "Validate PHPUnit < 10 config for use with PHPUnit 8"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunitlte9.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/schema/8.5.xsd"
+
+      - name: "Validate PHPUnit < 10 config for use with PHPUnit 9"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunitlte9.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/schema/9.5.xsd"
+
+      - name: "Validate PHPUnit 10+ config for use with PHPUnit 10"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/schema/10.5.xsd"
+
+      - name: "Validate PHPUnit 10+ config for use with PHPUnit 11"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/phpunit.xsd"
+
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
         id: phpcs


### PR DESCRIPTION
### GH Actions: split XML code style check off from "Basic QA"check 

The intention is for there to be a dedicated action runner available at some point for XML code style checking, so let's move this to a separate job.

Also see: #145

### GH Actions: use the xmllint-validate action runner 

Instead of doing all the installation steps for xmllint validation in the workflow, use the ✨ new dedicated `phpcsstandards/xmllint-validate` action runner instead.

Ref: https://github.com/marketplace/actions/xmllint-validate

### GH Actions: add some additional XML validation checks 

... for dev tool files.