### PR TITLE
Tests: as of PHPUnit 10 data provider methods should be static

### DIFF
--- a/Tests/DocsXsd/DocsXsdTest.php
+++ b/Tests/DocsXsd/DocsXsdTest.php
@@ -60,7 +60,7 @@ final class DocsXsdTest extends IOTestCase
      *
      * @return array
      */
-    public function dataValidXsd()
+    public static function dataValidXsd()
     {
         return [
             'Valid docs example with single standard in the file' => [
@@ -110,7 +110,7 @@ final class DocsXsdTest extends IOTestCase
      *
      * @return array
      */
-    public function dataInvalidXsd()
+    public static function dataInvalidXsd()
     {
         return [
             'Title attribute too long on <documentation> element' => [

--- a/Tests/FeatureComplete/Check/ColorTest.php
+++ b/Tests/FeatureComplete/Check/ColorTest.php
@@ -65,7 +65,7 @@ final class ColorTest extends CheckTestCase
      *
      * @return array
      */
-    public function dataColors()
+    public static function dataColors()
     {
         return [
             'feature complete - header' => [

--- a/Tests/FeatureComplete/Check/MarkProgressTest.php
+++ b/Tests/FeatureComplete/Check/MarkProgressTest.php
@@ -104,7 +104,7 @@ No orphaned documentation or test files found.';
      *
      * @return array
      */
-    public function dataProgress()
+    public static function dataProgress()
     {
         return [
             'single line progress reporting (<= 60 sniffs)'      => [

--- a/Tests/FeatureComplete/Check/NoSniffsTest.php
+++ b/Tests/FeatureComplete/Check/NoSniffsTest.php
@@ -77,7 +77,7 @@ No orphaned documentation or test files found\.[\r\n]+$`';
      *
      * @return array
      */
-    public function dataTargetDoesntContainSniffs()
+    public static function dataTargetDoesntContainSniffs()
     {
         return [
             'empty directory'                            => ['EmptyDir'],

--- a/Tests/FeatureComplete/Check/ValidStandardsTest.php
+++ b/Tests/FeatureComplete/Check/ValidStandardsTest.php
@@ -63,7 +63,7 @@ No orphaned documentation or test files found.';
      *
      * @return array
      */
-    public function dataFeatureCompleteStandard()
+    public static function dataFeatureCompleteStandard()
     {
         return [
             'feature complete with CSS test files'      => [

--- a/Tests/FeatureComplete/Config/GetHelpTest.php
+++ b/Tests/FeatureComplete/Config/GetHelpTest.php
@@ -107,7 +107,7 @@ Options:
      *
      * @return array
      */
-    public function dataShowHelp()
+    public static function dataShowHelp()
     {
         return [
             '-h'     => [

--- a/Tests/FeatureComplete/Config/GetVersionTest.php
+++ b/Tests/FeatureComplete/Config/GetVersionTest.php
@@ -49,7 +49,7 @@ final class GetVersionTest extends XTestCase
      *
      * @return array
      */
-    public function dataShowVersion()
+    public static function dataShowVersion()
     {
         return [
             '-V'        => [

--- a/Tests/FeatureComplete/Config/MagicMethodsTest.php
+++ b/Tests/FeatureComplete/Config/MagicMethodsTest.php
@@ -65,7 +65,7 @@ final class MagicMethodsTest extends XTestCase
      *
      * @return void
      */
-    public function dataGet()
+    public static function dataGet()
     {
         return [
             'property which doesn\'t exist on the class' => [
@@ -104,7 +104,7 @@ final class MagicMethodsTest extends XTestCase
      *
      * @return void
      */
-    public function dataIsset()
+    public static function dataIsset()
     {
         return [
             'property which doesn\'t exist on the class' => [
@@ -167,7 +167,7 @@ final class MagicMethodsTest extends XTestCase
      *
      * @return void
      */
-    public function dataSetUnset()
+    public static function dataSetUnset()
     {
         return [
             'property which doesn\'t exist on the class' => ['doesnotexist'],

--- a/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
+++ b/Tests/FeatureComplete/Config/ProcessCliCommandTest.php
@@ -73,7 +73,7 @@ final class ProcessCliCommandTest extends XTestCase
      *
      * @return array
      */
-    public function dataProcessCliCommandUnsupportedArgument()
+    public static function dataProcessCliCommandUnsupportedArgument()
     {
         return [
             'Unsupported short arguments' => [
@@ -141,7 +141,7 @@ final class ProcessCliCommandTest extends XTestCase
      *
      * @return array
      */
-    public function dataProcessCliCommand()
+    public static function dataProcessCliCommand()
     {
         /*
          * For project root, we only really verify that it has been set as the value will depend
@@ -402,7 +402,7 @@ final class ProcessCliCommandTest extends XTestCase
      *
      * @return array
      */
-    public function dataProcessCliCommandOutputOnlyArgs()
+    public static function dataProcessCliCommandOutputOnlyArgs()
     {
         /*
          * For project root, we only verify that it has been set as the value will depend on the


### PR DESCRIPTION
Per the PHPUnit manual: "A data provider method must be public and static" (https://docs.phpunit.de/en/12.0/writing-tests-for-phpunit.html).

A similar change was done in the PHPCS repository: https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/255

Tests will continue to work when running with PHPUnit < 10.