### PR TITLE
Add FeatureComplete tests to phpunitlte9.xml.dist

### DIFF
--- a/phpunitlte9.xml.dist
+++ b/phpunitlte9.xml.dist
@@ -18,6 +18,7 @@
         </testsuite>
         <testsuite name="DevTools">
             <directory suffix="Test.php">./Tests/DocsXsd/</directory>
+            <directory suffix="Test.php">./Tests/FeatureComplete/</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
phpunitlte9.xml.dist was added first to the `stable` branch (see https://github.com/PHPCSStandards/PHPCSDevTools/pull/162) and then to the `develop` branch, but FeatureComplete currently exists only in the `develop` branch. That is probably why the tests were not added to phpunitlte9.xml.dist before.