### PR TITLE
GH Actions: add markdown linting and yaml linting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,8 @@
 /.gitignore              export-ignore
 /.github                 export-ignore
 /.markdownlint-cli2.yaml export-ignore
+/.remarkignore           export-ignore
+/.remarkrc               export-ignore
 /phpcs.xml.dist          export-ignore
 /phpstan.neon.dist       export-ignore
 /phpunit.xml.dist        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,16 +5,17 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
-/.gitattributes        export-ignore
-/.gitignore            export-ignore
-/.github               export-ignore
-/phpcs.xml.dist        export-ignore
-/phpstan.neon.dist     export-ignore
-/phpunit.xml.dist      export-ignore
-/phpunitlte9.xml.dist  export-ignore
-/phpunit-bootstrap.php export-ignore
-/PHPCSDebug/Tests      export-ignore
-/Tests                 export-ignore
+/.gitattributes          export-ignore
+/.gitignore              export-ignore
+/.github                 export-ignore
+/.markdownlint-cli2.yaml export-ignore
+/phpcs.xml.dist          export-ignore
+/phpstan.neon.dist       export-ignore
+/phpunit.xml.dist        export-ignore
+/phpunitlte9.xml.dist    export-ignore
+/phpunit-bootstrap.php   export-ignore
+/PHPCSDebug/Tests        export-ignore
+/Tests                   export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 /.markdownlint-cli2.yaml export-ignore
 /.remarkignore           export-ignore
 /.remarkrc               export-ignore
+/.yamllint.yml           export-ignore
 /phpcs.xml.dist          export-ignore
 /phpstan.neon.dist       export-ignore
 /phpunit.xml.dist        export-ignore

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -150,3 +150,9 @@ jobs:
   remark:
     name: 'QA Markdown'
     uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main
+
+  yamllint:
+    name: 'Lint Yaml'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
+    with:
+      strict: true

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -146,3 +146,7 @@ jobs:
   markdownlint:
     name: 'Lint Markdown'
     uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+
+  remark:
+    name: 'QA Markdown'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@main

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -142,3 +142,7 @@ jobs:
 
   phpstan:
     uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main
+
+  markdownlint:
+    name: 'Lint Markdown'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -32,7 +32,7 @@ jobs:
           - php: '5.4'
             phpcs_version: '3.1.0'
 
-    name: "QTest${{ matrix.lint && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+    name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
     steps:
       - name: Checkout code
@@ -98,12 +98,16 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
+        # yamllint disable rule:line-length
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+        # yamllint enable rule:line-length
 
       - name: Determine PHPUnit composer script to use
         id: phpunit_script
         run: |
-          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) || startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'SUFFIX=' >> "$GITHUB_OUTPUT"
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
             echo 'SUFFIX=' >> "$GITHUB_OUTPUT"
           else
             echo 'SUFFIX=-lte9' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,12 +158,16 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
+        # yamllint disable rule:line-length
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
+        # yamllint enable rule:line-length
 
       - name: Determine PHPUnit composer script to use
         id: phpunit_script
         run: |
-          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) || startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'SUFFIX=' >> "$GITHUB_OUTPUT"
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
             echo 'SUFFIX=' >> "$GITHUB_OUTPUT"
           else
             echo 'SUFFIX=-lte9' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -94,10 +94,10 @@ jobs:
           build_dir: 'deploy'
           target_branch: 'gh-pages'
           keep_history: true
-          #allow_empty_commit: false # Turn on after verification that it all works as expected.
+          allow_empty_commit: false
           jekyll: true
           commit_message: ${{ steps.commit_msg.outputs.MSG }}
           dry_run: ${{ steps.base_branch.outputs.BRANCH != 'stable' }}
-          verbose: ${{ matrix.verbose }}
+          verbose: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 deploy/
+node_modules/
 vendor/
 composer.lock
 .phpcs.xml

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,121 @@
+#
+# Configuration file for MarkdownLint-CLI2.
+#
+# Example file with all options:
+# https://github.com/DavidAnson/markdownlint-cli2/blob/main/test/markdownlint-cli2-yaml-example/.markdownlint-cli2.yaml
+#
+
+# Do not fix any fixable errors.
+fix: false
+
+# Define glob expressions to use (only valid at root).
+globs:
+  - "**/*.md"
+  - ".github/**/*.md"
+
+# Show found files on stdout (only valid at root)
+showFound: true
+
+# Define glob expressions to ignore.
+ignores:
+  - "node_modules/"
+  - "vendor/"
+
+# Disable inline config comments.
+noInlineConfig: true
+
+# Disable progress on stdout (only valid at root).
+noProgress: false
+
+# Adjust the configuration for some built-in rules.
+# For full information on the options and defaults, see:
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+config:
+  ######################
+  # Disable a few rules.
+  ######################
+  # MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines.
+  MD031: false
+  # MD032/blanks-around-lists - Lists should be surrounded by blank lines.
+  MD032: false
+
+  ##############################
+  # Customize a few other rules.
+  ##############################
+  # MD003/heading-style/header-style - Heading style.
+  MD003:
+    # Heading style - Always use hashes.
+    style: "atx"
+
+  # MD004/ul-style - Unordered list style.
+  MD004:
+    # List style - each level has a different, but consistent symbol.
+    style: "sublist"
+
+  # MD007/ul-indent - Unordered list indentation.
+  MD007:
+    indent: 4
+    # Whether to indent the first level of the list.
+    start_indented: false
+
+  # MD012/no-multiple-blanks - Multiple consecutive blank lines.
+  MD012:
+    maximum: 2
+
+  # MD013/line-length - Line length.
+  MD013:
+    # Number of characters. No need for being too fussy.
+    line_length: 1000
+    # Number of characters for headings.
+    heading_line_length: 100
+    # Number of characters for code blocks.
+    code_block_line_length: 140
+    # Stern length checking (applies to tables, code blocks etc which have their own max line length).
+    stern: true
+
+  # MD022/blanks-around-headings : Headings should be surrounded by blank lines.
+  MD022:
+    # Blank lines above heading
+    lines_above: [2, 1, 1, 1, 1]
+    # Blank lines below heading
+    lines_below: [1, 1, -1, -1, -1]
+
+  # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content.
+  MD024:
+    # Only check sibling headings.
+    siblings_only: true
+
+  # MD033/no-inline-html - Inline HTML.
+  MD033:
+    # Allowed elements.
+    allowed_elements:
+      - div
+      - details
+      - summary
+      - b
+      - code
+      - ul
+      - li
+
+  # MD044/proper-names - Proper names should have the correct capitalization.
+  MD044:
+    # List of proper names.
+    names: ["PHPDevTools", "PHPCSUtils", "PHP", "PHP_CodeSniffer", "CodeSniffer", "PHPUnit"]
+    # Include code blocks.
+    code_blocks: false
+
+  # MD046/code-block-style - Code block style
+  MD046:
+    style: "fenced"
+
+  # MD048/code-fence-style - Code fence style
+  MD048:
+    style: "backtick"
+
+  # MD049/emphasis-style - Emphasis style should be consistent
+  MD049:
+    style: "underscore"
+
+  # MD050/strong-style - Strong style should be consistent
+  MD050:
+    style: "asterisk"

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,5 @@
+# Ignore rules for Remark.
+# Docs: https://github.com/unifiedjs/unified-engine/blob/HEAD/doc/ignore.md
+
+/node_modules/
+/vendor/

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,46 @@
+{
+  "plugins": [
+    "remark-gfm",
+    ["remark-lint-checkbox-character-style", "consistent"],
+    ["remark-lint-checkbox-content-indent", "consistent"],
+    "remark-lint-definition-spacing",
+    "remark-lint-file-extension",
+    ["remark-lint-linebreak-style", "unix"],
+    ["remark-lint-link-title-style", "\""],
+    ["remark-lint-ordered-list-marker-style", "."],
+    [
+        "remark-lint-no-dead-urls",
+        {
+            "skipUrlPatterns": [
+                "https://packagist.org/packages/phpcsstandards/phpcsdevtools#dev-develop"
+            ],
+            "deadOrAliveOptions": {
+                "maxRetries": 3
+            }
+        }
+    ],
+    "remark-lint-no-duplicate-defined-urls",
+    "remark-lint-no-duplicate-definitions",
+    "remark-lint-no-empty-url",
+    "remark-lint-no-file-name-consecutive-dashes",
+    ["remark-lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9_-"],
+    "remark-lint-no-file-name-outer-dashes",
+    "remark-lint-no-heading-like-paragraph",
+    "remark-lint-no-literal-urls",
+    "remark-lint-no-reference-like-url",
+    "remark-lint-no-shortcut-reference-image",
+    "remark-lint-no-table-indentation",
+    "remark-lint-no-undefined-references",
+    "remark-lint-no-unneeded-full-reference-image",
+    "remark-lint-no-unneeded-full-reference-link",
+    "remark-lint-no-unused-definitions",
+    ["remark-lint-strikethrough-marker", "~~"],
+    ["remark-lint-table-cell-padding", "consistent"],
+    "remark-lint-heading-whitespace",
+    "remark-lint-list-item-punctuation",
+    "remark-lint-match-punctuation",
+    "remark-lint-no-hr-after-heading",
+    "remark-lint-are-links-valid-duplicate",
+    "remark-validate-links"
+  ]
+}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,23 @@
+# Details on the default config:
+# https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+  - 'phpstan.neon*'
+
+# Rule documentation: https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  colons:
+    max-spaces-after: -1  # Disabled to allow aligning of values.
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: {}
+  document-start:
+    present: false
+  line-length:
+    max: 145
+  truthy:
+    allowed-values: ["true", "false", "on", "off"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses [Semantic Versioning](http://semver.org/).
+This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/) and uses [Semantic Versioning](https://semver.org/).
 
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log for the PHPCSDevTools standard for PHP Codesniffer
+# Change Log for the PHPCSDevTools standard for PHP_CodeSniffer
 
 All notable changes to this project will be documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-PHPCSDevTools for developers of PHP_CodeSniffer sniffs
-=====================================================
+# PHPCSDevTools for developers of PHP_CodeSniffer sniffs
 
 <div aria-hidden="true">
 
@@ -34,8 +33,7 @@ This is a set of tools to assist developers of sniffs for [PHP CodeSniffer](http
 * [License](#license)
 
 
-Installation
--------------------------------------------
+## Installation
 
 ### Composer Project-based Installation
 
@@ -72,8 +70,7 @@ Composer will automatically install dependencies and register the PHPCSDebug sta
    ```
 
 
-Features
-------------------------------
+## Features
 
 ### Checking whether all sniffs in a PHPCS standard are feature complete
 
@@ -94,7 +91,7 @@ php -f "path/to/PHPCSDevTools/bin/phpcs-check-feature-completeness"
 If all is good, you will see a `All # sniffs are accompanied by unit tests and documentation.` message.
 
 If there are files missing, you will see errors/warnings for each missing file, like so:
-```
+```text
 WARNING: Documentation missing for path/to/project/StandardName/Sniffs/Category/SniffNameSniff.php.
 ERROR: Unit tests missing for path/to/project/StandardName/Sniffs/Category/SniffNameSniff.php.
 ```
@@ -105,7 +102,7 @@ phpcs-check-feature-completeness ./StandardName
 ```
 
 #### Options
-```
+```text
 directories   One or more specific directories to examine.
               Defaults to the directory from which the script is run.
 -q, --quiet   Turn off warnings for missing documentation.
@@ -143,7 +140,7 @@ phpcs ./SniffNameUnitTest.inc --standard=YourStandard,PHPCSDebug --sniffs=YourSt
 ```
 
 The output will look something along the lines of:
-```
+```text
 Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
 -------------------------------------------------------------------------
   0 | L1 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  5]: <?php
@@ -174,7 +171,7 @@ Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
  21 | L5 | C  6 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
 ```
 
-PHPCS itself can also display similar information using the `-vv` or `-vvv` verbosity flags, however, when using those, you will receive a *lot* more information than just the token list and, while useful for debugging PHPCS itself, the additional information is mostly just noise when developing a sniff.
+PHPCS itself can also display similar information using the `-vv` or `-vvv` verbosity flags, however, when using those, you will receive a _lot_ more information than just the token list and, while useful for debugging PHPCS itself, the additional information is mostly just noise when developing a sniff.
 
 ### Documentation XSD Validation
 
@@ -229,12 +226,12 @@ jobs:
 
 :point_right: You'll need to replace the `YourRuleset` within the command with the name of your ruleset (of course).
 
-Contributing
--------
+## Contributing
+
 Contributions to this project are welcome. Clone this repository, branch off from `develop`, make your changes, commit them and send in a pull request.
 
 If unsure whether the changes you are proposing would be welcome, open an issue first to discuss your proposal.
 
-License
--------
+## License
+
 This code is released under the [GNU Lesser General Public License (LGPLv3)](http://www.gnu.org/copyleft/lesser.html).

--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 <div aria-hidden="true">
 
-[![Latest Stable Version](https://poser.pugx.org/phpcsstandards/phpcsdevtools/v/stable)](https://packagist.org/packages/phpcsstandards/phpcsdevtools)
-[![Release Date of the Latest Version](https://img.shields.io/github/release-date/PHPCSStandards/PHPCSDevTools.svg?maxAge=1800)](https://github.com/PHPCSStandards/PHPCSDevTools/releases)
+[![Latest Stable Version](https://img.shields.io/packagist/v/phpcsstandards/phpcsdevtools?label=stable)][phpcsdevtools-packagist]
+[![Release Date of the Latest Version](https://img.shields.io/github/release-date/PHPCSStandards/PHPCSDevTools.svg?maxAge=1800)][phpcsdevtools-releases]
 [![Changelog](https://img.shields.io/github/v/release/PHPCSStandards/PHPCSDevTools?label=Changelog&sort=semver)](https://github.com/PHPCSStandards/PHPCSDevTools/blob/stable/CHANGELOG.md)
 :construction:
 [![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/phpcsstandards/phpcsdevtools#dev-develop)
 [![Last Commit to Unstable](https://img.shields.io/github/last-commit/PHPCSStandards/PHPCSDevTools/develop.svg)](https://github.com/PHPCSStandards/PHPCSDevTools/commits/develop)
 
-[![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/phpcsdevtools.svg?maxAge=3600)](https://packagist.org/packages/phpcsstandards/phpcsdevtools)
-[![Build Status CS](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/cs.yml/badge.svg)](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/cs.yml)
-[![Build Status Test](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/test.yml/badge.svg)](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/test.yml)
+[![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/phpcsstandards/phpcsdevtools/php.svg)][phpcsdevtools-packagist]
+[![Build Status CS](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/cs.yml/badge.svg)][gha-qa-results]
+[![Build Status Test](https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/test.yml/badge.svg)][gha-test-results]
 [![Tested on PHP 5.4 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://github.com/PHPCSStandards/PHPCSDevTools/actions?query=workflow%3ATest)
 
-[![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsdevtools/license)](https://github.com/PHPCSStandards/PHPCSDevTools/blob/stable/LICENSE)
+[![License: LGPLv3](https://img.shields.io/github/license/PHPCSStandards/PHPCSDevTools)](https://github.com/PHPCSStandards/PHPCSDevTools/blob/stable/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)
 
 </div>
 
-This is a set of tools to assist developers of sniffs for [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
+This is a set of tools to assist developers of sniffs for [PHP CodeSniffer][phpcs-gh].
 
 * [Installation](#installation)
     + [Composer Project-based Installation](#composer-project-based-installation)
@@ -56,9 +56,9 @@ Composer will automatically install dependencies and register the PHPCSDebug sta
 
 ### Stand-alone Installation
 
-* Install [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) via [your preferred method](https://github.com/PHPCSStandards/PHP_CodeSniffer#installation).
+* Install [PHP CodeSniffer][phpcs-gh] via [your preferred method][phpcs-gh-install].
 * Register the path to PHPCS in your system `$PATH` environment variable to make the `phpcs` command available from anywhere in your file system.
-* Download the [latest PHPCSDevTools release](https://github.com/PHPCSStandards/PHPCSDevTools/releases) and unzip/untar it into an arbitrary directory.
+* Download the [latest PHPCSDevTools release][phpcsdevtools-releases] and unzip/untar it into an arbitrary directory.
     You can also choose to clone this repository using git.
 * Add the path to the directory in which you placed your copy of the PHPCSDevTools repo to the PHP CodeSniffer configuration using the below command:
    ```bash
@@ -175,7 +175,7 @@ PHPCS itself can also display similar information using the `-vv` or `-vvv` verb
 
 ### Documentation XSD Validation
 
-This project contains an [XML Schema Definition (XSD)](https://www.w3.org/standards/xml/schema) to allow for validation PHPCS documentation XML files. Following the XSD will make sure your documentation can be correctly displayed when using the PHPCS `--generator` option.
+This project contains an [XML Schema Definition (XSD)](https://www.w3.org/TR/xmlschema11-1/) to allow for validation PHPCS documentation XML files. Following the XSD will make sure your documentation can be correctly displayed when using the PHPCS `--generator` option.
 
 In order to use it, you'll need to add the schema related attributes to the `documentation` element of the sniff documentation file, like so:
 
@@ -234,4 +234,13 @@ If unsure whether the changes you are proposing would be welcome, open an issue 
 
 ## License
 
-This code is released under the [GNU Lesser General Public License (LGPLv3)](http://www.gnu.org/copyleft/lesser.html).
+This code is released under the [GNU Lesser General Public License (LGPLv3)](LICENSE).
+
+
+[phpcsdevtools-packagist]: https://packagist.org/packages/phpcsstandards/phpcsdevtools
+[phpcsdevtools-releases]:  https://github.com/PHPCSStandards/PHPCSDevTools/releases
+[gha-qa-results]:          https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/cs.yml
+[gha-test-results]:        https://github.com/PHPCSStandards/PHPCSDevTools/actions/workflows/test.yml
+
+[phpcs-gh]:                https://github.com/PHPCSStandards/PHP_CodeSniffer
+[phpcs-gh-install]:        https://github.com/PHPCSStandards/PHP_CodeSniffer#installation

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    #phpVersion: 50400 # Needs to be 70100 or higher... sigh...
+    # phpVersion: 50400 # Needs to be 70100 or higher... sigh...
     level: 6
     paths:
         - bin


### PR DESCRIPTION
### GH Actions: add new check for consistency in markdown files 

This new check uses the NPM MarkdownLint package via the NPM MarkdownLint-CLI2 package.

It executes a loose check for consistency and some common errors.
Some of the more annoying rules/rules which could impact display of markdown files on GitHub have been disabled.

All necessary configuration is contained in the `.markdownlint-cli2.yaml` file.

To run locally, install via:
```bash
npm install -g markdownlint-cli2
```
... and then run via:
```bash
markdownlint-cli2
```

Includes a problem matcher in the reusable workflow, which _should_ allow for displaying the results inline in GitHub PR code review view.

Includes adding the config file to `.gitattributes`.
Includes adding `node_modules` to the `.gitignore` in case anyone would install these tools locally (to prevent them committing them).

Refs:
* https://github.com/DavidAnson/markdownlint
* https://github.com/DavidAnson/markdownlint-cli2

### Docs: tweak markdown for compliance with markdownlint

### GH Actions: add new check with additional QA for markdown files 

While MarkdownLint is absolutely great for finding formatting issues, Remark offers some additional "rules" which are useful, such as checking that links and link definitions match up, verifying all used links work and some additional formatting checks which markdownlint just doesn't offer.

An extensive effort has been made to prevent duplication of messages between the Markdownlint and the Remark check. This includes ensuring there are no conflicting rules.

The rule configuration is contained in the `.remarkrc` file.

Files/directories to be ignored can be listed in the `.remarkignore` file which supports glob syntax, like `.gitignore`.
Note: `.`-prefixed files and directories are excluded by default. To include those in the scan, they have to be passed explicitly on the command-line.

Refs:
* https://github.com/remarkjs/remark/tree/main/packages/remark-cli
* https://github.com/remarkjs/remark-lint
* https://github.com/remarkjs/remark-gfm
* https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent
* https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended
* https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide

Additional (external) plugins included:
* https://github.com/vhf/remark-lint-heading-whitespace
* https://github.com/wemake-services/remark-lint-list-item-punctuation
* https://github.com/laysent/remark-lint-plugins/tree/HEAD/packages/remark-lint-match-punctuation
* https://github.com/olizilla/remark-lint-no-hr-after-heading
* https://github.com/wemake-services/remark-lint-are-links-valid
* https://github.com/remarkjs/remark-validate-links

### Docs: fix various links

### GH Actions: add Yamllint to QA basics 

... to loosely safeguard valid and consistent yaml files.

Includes adding a configuration file which loosens up the `default` ruleset to a degree I'm comfortable with.

Ref: https://yamllint.readthedocs.io/

### Yaml: various tweaks for compliance with Yamllint and actionlint