### PR TITLE
GH Actions: run DevTools tests on Windows

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -17,27 +17,37 @@ concurrency:
 jobs:
   # Run CI checks/tests which have no dependency on the PHPCS version used.
   quicktest-php:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: ['ubuntu-latest', 'windows-latest']
         php: ['5.4', 'latest']
 
-    name: "QTest + Lint: PHP ${{ matrix.php }}"
+    name: "QTest + Lint: PHP ${{ matrix.php }} - OS ${{ matrix.os }}"
 
     steps:
+      - name: Prepare git to leave line endings alone
+        run: git config --global core.autocrlf input
+
       - name: Checkout code
         uses: actions/checkout@v4
 
       # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
       # This should not be blocking for this job, so ignore any errors from this step.
       # Ref: https://github.com/dotnet/core/issues/4167
-      - name: Update the available packages list
+      - name: Update the available packages list (Linux)
+        if: runner.os == 'Linux'
         continue-on-error: true
         run: sudo apt-get update
 
-      - name: Install xmllint
+      - name: Install xmllint (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      - name: Install xmllint (Windows)
+        if: runner.os == 'Windows'
+        run: choco install xsltproc
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -70,12 +80,14 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
+        shell: bash
         # yamllint disable rule:line-length
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
         # yamllint enable rule:line-length
 
       - name: Determine PHPUnit composer script to use
         id: phpunit_script
+        shell: bash
         run: |
           if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
             echo 'SUFFIX=' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -24,7 +24,7 @@ jobs:
         os: ['ubuntu-latest', 'windows-latest']
         php: ['5.4', 'latest']
 
-    name: "QTest + Lint: PHP ${{ matrix.php }} - OS ${{ matrix.os }}"
+    name: "QTest + Lint: PHP ${{ matrix.php }} (${{ matrix.os == 'windows-latest' && 'Win' || 'Linux' }})"
 
     steps:
       - name: Prepare git to leave line endings alone

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         os: ['ubuntu-latest', 'windows-latest']
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
-    name: "Test + Lint: PHP ${{ matrix.php }} - OS ${{ matrix.os }}"
+    name: "Test + Lint: PHP ${{ matrix.php }} (${{ matrix.os == 'windows-latest' && 'Win' || 'Linux' }})"
 
     continue-on-error: ${{ matrix.php == '8.5' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,29 +18,39 @@ concurrency:
 jobs:
   # Run CI checks/tests which have no dependency on the PHPCS version used.
   test-php:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: ['ubuntu-latest', 'windows-latest']
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
-    name: "Test + Lint: PHP ${{ matrix.php }}"
+    name: "Test + Lint: PHP ${{ matrix.php }} - OS ${{ matrix.os }}"
 
     continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
+      - name: Prepare git to leave line endings alone
+        run: git config --global core.autocrlf input
+
       - name: Checkout code
         uses: actions/checkout@v4
 
       # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
       # This should not be blocking for this job, so ignore any errors from this step.
       # Ref: https://github.com/dotnet/core/issues/4167
-      - name: Update the available packages list
+      - name: Update the available packages list (Linux)
+        if: runner.os == 'Linux'
         continue-on-error: true
         run: sudo apt-get update
 
-      - name: Install xmllint
+      - name: Install xmllint (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      - name: Install xmllint (Windows)
+        if: runner.os == 'Windows'
+        run: choco install xsltproc
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -75,12 +85,14 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
+        shell: bash
         # yamllint disable rule:line-length
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
         # yamllint enable rule:line-length
 
       - name: Determine PHPUnit composer script to use
         id: phpunit_script
+        shell: bash
         run: |
           if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
             echo 'SUFFIX=' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR changes both the test.yml and the quicktest.yml workflows to run the tests on Windows as well. Before, the tests were executed only on Linux.

Installing xmllint on Windows using Chocolatey is a bit slow. We can look into ways to make it faster if needed.

Another thing to consider is whether we need to run all the test variations on Windows, as done in this PR. If not, this should speed up a bit the total time for all the checks to complete.