### PR TITLE
PHPCSDebug ruleset: update schema URL

### DIFF
--- a/PHPCSDebug/ruleset.xml
+++ b/PHPCSDebug/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDebug" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSDebug" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Sniffs which can be used as debugging tools for PHPCS developers</description>
 


### PR DESCRIPTION
PHPCS now offers permalinks for the schema.

Ref: PHPCSStandards/PHP_CodeSniffer#1094