### PR TITLE
Officially support PHP_CodeSniffer 4.0

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -95,13 +95,22 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['dev-master']
+        phpcs_version: ['3.1.0', 'dev-master']
+
+        exclude:
+          # PHP 3.1.0 is incompatible with PHP >= 8.0.
+          - php: 'latest'
+            phpcs_version: '3.1.0'
 
         include:
+          # Replacement build for "low" PHPCS 3.x on PHP latest.
+          - php: 'latest'
+            phpcs_version: '3.8.0'
+
           - php: '7.2'
-            phpcs_version: '3.1.0'
-          - php: '5.4'
-            phpcs_version: '3.1.0'
+            phpcs_version: '4.x-dev'
+          - php: 'latest'
+            phpcs_version: '4.x-dev'
 
     name: "QTest: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -114,7 +123,7 @@ jobs:
       - name: Setup ini config
         id: set_ini
         run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+          if [ "${{ contains( matrix.phpcs_version, 'dev' ) }}" != "true" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
@@ -129,10 +138,10 @@ jobs:
 
       - name: 'Composer: adjust dependencies'
         run: |
-          # Set the PHPCS version to be used in the tests.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts --no-interaction
           # Remove the PHPCSDevCS dependency as it has different PHPCS requirements and would block installs.
           composer remove --no-update --dev phpcsstandards/phpcsdevcs --no-scripts --no-interaction
+          # Set the PHPCS version to be used in the tests.
+          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,56 +110,55 @@ jobs:
         # - PHP 8.2 needs PHPCS 3.6.1+ to run without errors.
         # - PHP 8.3 needs PHPCS 3.8.0+ to run without errors (though the errors don't affect this package).
         # - PHP 8.4 needs PHPCS 3.8.0+ to run without errors (officially 3.11.0, but 3.8.0 will work fine).
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2']
-        phpcs_version: ['3.1.0', 'dev-master']
+        #
+        # Additionally, PHPCS 4.x has a minimum version requirement of PHP 7.2.
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        phpcs_version: ['dev-master', '4.x-dev']
+
+        exclude:
+          - php: '5.4'
+            phpcs_version: '4.x-dev'
+          - php: '5.5'
+            phpcs_version: '4.x-dev'
+          - php: '5.6'
+            phpcs_version: '4.x-dev'
+          - php: '7.0'
+            phpcs_version: '4.x-dev'
+          - php: '7.1'
+            phpcs_version: '4.x-dev'
 
         include:
           # Complete the matrix, while preventing issues with PHPCS versions incompatible with certain PHP versions.
-          - php: '7.3'
-            phpcs_version: 'dev-master'
+          - php: '5.4'
+            phpcs_version: '3.1.0'
+          - php: '5.5'
+            phpcs_version: '3.1.0'
+          - php: '5.6'
+            phpcs_version: '3.1.0'
+          - php: '7.0'
+            phpcs_version: '3.1.0'
+          - php: '7.1'
+            phpcs_version: '3.1.0'
+          - php: '7.2'
+            phpcs_version: '3.1.0'
           - php: '7.3'
             phpcs_version: '3.3.1'
-
-          - php: '7.4'
-            phpcs_version: 'dev-master'
           - php: '7.4'
             phpcs_version: '3.5.0'
-
-          - php: '8.0'
-            phpcs_version: 'dev-master'
           - php: '8.0'
             phpcs_version: '3.5.7'
-
-          - php: '8.1'
-            phpcs_version: 'dev-master'
           - php: '8.1'
             phpcs_version: '3.6.1'
-
-          - php: '8.2'
-            phpcs_version: 'dev-master'
           - php: '8.2'
             phpcs_version: '3.6.1'
-
-          - php: '8.3'
-            phpcs_version: 'dev-master'
           - php: '8.3'
             phpcs_version: '3.8.0'
-
-          - php: '8.4'
-            phpcs_version: 'dev-master'
           - php: '8.4'
             phpcs_version: '3.8.0'
-
-          # Experimental builds. These are allowed to fail.
-          - php: '7.4'
-            phpcs_version: '4.0.x-dev'
-
-          - php: '8.5' # Nightly.
-            phpcs_version: 'dev-master'
 
     name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
-    continue-on-error: ${{ matrix.php == '8.5' || matrix.phpcs_version == '4.0.x-dev' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
       - name: Checkout code
@@ -170,7 +169,7 @@ jobs:
         run: |
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-          if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
+          if [ "${{ contains( matrix.phpcs_version, 'dev' ) }}" != "true" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
@@ -185,10 +184,10 @@ jobs:
 
       - name: 'Composer: adjust dependencies'
         run: |
-          # Set the PHPCS version to be used in the tests.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts --no-interaction
           # Remove the PHPCSDevCS dependency as it has different PHPCS requirements and would block installs.
           composer remove --no-update --dev phpcsstandards/phpcsdevcs --no-scripts --no-interaction
+          # Set the PHPCS version to be used in the tests.
+          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/PHPCSDebug/Tests/Debug/TokenListExpectationPhpcs3.txt
+++ b/PHPCSDebug/Tests/Debug/TokenListExpectationPhpcs3.txt
@@ -1,0 +1,65 @@
+
+Ptr | Ln  | Col  | Cond | ( #) | Token Type                 | [len]: Content
+--------------------------------------------------------------------------
+  0 | L01 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  5]: <?php
+
+  1 | L02 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+  2 | L03 | C  1 | CC 0 | ( 0) | T_DOC_COMMENT_OPEN_TAG     | [  3]: /**
+  3 | L03 | C  4 | CC 0 | ( 0) | T_DOC_COMMENT_WHITESPACE   | [  1]: ⸱
+  4 | L03 | C  5 | CC 0 | ( 0) | T_DOC_COMMENT_STRING       | [ 17]: Short Doc block.⸱
+  5 | L03 | C 22 | CC 0 | ( 0) | T_DOC_COMMENT_CLOSE_TAG    | [  2]: */
+  6 | L03 | C 24 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+  7 | L04 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [  8]: function
+  8 | L04 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+  9 | L04 | C 10 | CC 0 | ( 0) | T_STRING                   | [  4]: name
+ 10 | L04 | C 14 | CC 0 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+ 11 | L04 | C 15 | CC 0 | ( 1) | T_VARIABLE                 | [  6]: $param
+ 12 | L04 | C 21 | CC 0 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 13 | L04 | C 22 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 14 | L04 | C 23 | CC 0 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 15 | L04 | C 24 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 16 | L05 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱ | Orig: →
+ 17 | L05 | C  5 | CC 1 | ( 0) | T_IF                       | [  2]: if
+ 18 | L05 | C  7 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 19 | L05 | C  8 | CC 1 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+ 20 | L05 | C  9 | CC 1 | ( 1) | T_VARIABLE                 | [ 10]: $condition
+ 21 | L05 | C 19 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 22 | L05 | C 20 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
+ 23 | L05 | C 23 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 24 | L05 | C 24 | CC 1 | ( 1) | T_CONSTANT_ENCAPSED_STRING | [  7]: 'q⸱⸱⸱a' | Orig: 'q→a'
+ 25 | L05 | C 31 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 26 | L05 | C 32 | CC 1 | ( 1) | T_BOOLEAN_AND              | [  2]: &&
+ 27 | L05 | C 34 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 28 | L05 | C 35 | CC 1 | ( 1) | T_VARIABLE                 | [  6]: $param
+ 29 | L05 | C 41 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 30 | L05 | C 42 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
+ 31 | L05 | C 45 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 32 | L05 | C 46 | CC 1 | ( 1) | T_FALSE                    | [  5]: false
+ 33 | L05 | C 51 | CC 1 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 34 | L05 | C 52 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 35 | L05 | C 53 | CC 1 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 36 | L05 | C 54 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 37 | L06 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  8]: ⸱⸱⸱⸱⸱⸱⸱⸱
+ 38 | L06 | C  9 | CC 2 | ( 0) | T_COMMENT                  | [ 16]: /* Do something.
+
+ 39 | L07 | C  1 | CC 2 | ( 0) | T_COMMENT                  | [ 24]: ⸱⸱⸱⸱⸱⸱⸱⸱⸱*⸱Multi-line⸱*/ | Orig: →→⸱*⸱Multi-line⸱*/
+ 40 | L07 | C 25 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 41 | L08 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 42 | L08 | C  5 | CC 1 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 43 | L08 | C  6 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 44 | L09 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 45 | L09 | C  5 | CC 1 | ( 0) | T_RETURN                   | [  6]: return
+ 46 | L09 | C 11 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 47 | L09 | C 12 | CC 1 | ( 0) | T_VARIABLE                 | [  3]: $cl
+ 48 | L09 | C 15 | CC 1 | ( 0) | T_SEMICOLON                | [  1]: ;
+ 49 | L09 | C 16 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 50 | L10 | C  1 | CC 0 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 51 | L10 | C  2 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+

--- a/PHPCSDebug/Tests/Debug/TokenListExpectationPhpcs4.txt
+++ b/PHPCSDebug/Tests/Debug/TokenListExpectationPhpcs4.txt
@@ -1,0 +1,66 @@
+
+Ptr | Ln  | Col  | Cond | ( #) | Token Type                 | [len]: Content
+--------------------------------------------------------------------------
+  0 | L01 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  5]: <?php
+  1 | L01 | C  6 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+  2 | L02 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+  3 | L03 | C  1 | CC 0 | ( 0) | T_DOC_COMMENT_OPEN_TAG     | [  3]: /**
+  4 | L03 | C  4 | CC 0 | ( 0) | T_DOC_COMMENT_WHITESPACE   | [  1]: ⸱
+  5 | L03 | C  5 | CC 0 | ( 0) | T_DOC_COMMENT_STRING       | [ 17]: Short Doc block.⸱
+  6 | L03 | C 22 | CC 0 | ( 0) | T_DOC_COMMENT_CLOSE_TAG    | [  2]: */
+  7 | L03 | C 24 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+
+  8 | L04 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [  8]: function
+  9 | L04 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 10 | L04 | C 10 | CC 0 | ( 0) | T_STRING                   | [  4]: name
+ 11 | L04 | C 14 | CC 0 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+ 12 | L04 | C 15 | CC 0 | ( 1) | T_VARIABLE                 | [  6]: $param
+ 13 | L04 | C 21 | CC 0 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 14 | L04 | C 22 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 15 | L04 | C 23 | CC 0 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 16 | L04 | C 24 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 17 | L05 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱ | Orig: →
+ 18 | L05 | C  5 | CC 1 | ( 0) | T_IF                       | [  2]: if
+ 19 | L05 | C  7 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 20 | L05 | C  8 | CC 1 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
+ 21 | L05 | C  9 | CC 1 | ( 1) | T_VARIABLE                 | [ 10]: $condition
+ 22 | L05 | C 19 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 23 | L05 | C 20 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
+ 24 | L05 | C 23 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 25 | L05 | C 24 | CC 1 | ( 1) | T_CONSTANT_ENCAPSED_STRING | [  7]: 'q⸱⸱⸱a' | Orig: 'q→a'
+ 26 | L05 | C 31 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 27 | L05 | C 32 | CC 1 | ( 1) | T_BOOLEAN_AND              | [  2]: &&
+ 28 | L05 | C 34 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 29 | L05 | C 35 | CC 1 | ( 1) | T_VARIABLE                 | [  6]: $param
+ 30 | L05 | C 41 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 31 | L05 | C 42 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
+ 32 | L05 | C 45 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
+ 33 | L05 | C 46 | CC 1 | ( 1) | T_FALSE                    | [  5]: false
+ 34 | L05 | C 51 | CC 1 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
+ 35 | L05 | C 52 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 36 | L05 | C 53 | CC 1 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
+ 37 | L05 | C 54 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 38 | L06 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  8]: ⸱⸱⸱⸱⸱⸱⸱⸱
+ 39 | L06 | C  9 | CC 2 | ( 0) | T_COMMENT                  | [ 16]: /* Do something.
+
+ 40 | L07 | C  1 | CC 2 | ( 0) | T_COMMENT                  | [ 24]: ⸱⸱⸱⸱⸱⸱⸱⸱⸱*⸱Multi-line⸱*/ | Orig: →→⸱*⸱Multi-line⸱*/
+ 41 | L07 | C 25 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 42 | L08 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 43 | L08 | C  5 | CC 1 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 44 | L08 | C  6 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 45 | L09 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
+ 46 | L09 | C  5 | CC 1 | ( 0) | T_RETURN                   | [  6]: return
+ 47 | L09 | C 11 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
+ 48 | L09 | C 12 | CC 1 | ( 0) | T_VARIABLE                 | [  3]: $cl
+ 49 | L09 | C 15 | CC 1 | ( 0) | T_SEMICOLON                | [  1]: ;
+ 50 | L09 | C 16 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
+
+ 51 | L10 | C  1 | CC 0 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
+ 52 | L10 | C  2 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
+

--- a/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
+++ b/PHPCSDebug/Tests/Debug/TokenListUnitTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSDebug\Tests\Debug;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Util\Common;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
@@ -37,74 +38,13 @@ final class TokenListUnitTest extends UtilityMethodTestCase
      */
     public function testOutput()
     {
-        $expected = <<<'EOD'
-
-Ptr | Ln  | Col  | Cond | ( #) | Token Type                 | [len]: Content
---------------------------------------------------------------------------
-  0 | L01 | C  1 | CC 0 | ( 0) | T_OPEN_TAG                 | [  5]: <?php
-
-  1 | L02 | C  1 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
-
-  2 | L03 | C  1 | CC 0 | ( 0) | T_DOC_COMMENT_OPEN_TAG     | [  3]: /**
-  3 | L03 | C  4 | CC 0 | ( 0) | T_DOC_COMMENT_WHITESPACE   | [  1]: ⸱
-  4 | L03 | C  5 | CC 0 | ( 0) | T_DOC_COMMENT_STRING       | [ 17]: Short Doc block.⸱
-  5 | L03 | C 22 | CC 0 | ( 0) | T_DOC_COMMENT_CLOSE_TAG    | [  2]: */
-  6 | L03 | C 24 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
-
-  7 | L04 | C  1 | CC 0 | ( 0) | T_FUNCTION                 | [  8]: function
-  8 | L04 | C  9 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
-  9 | L04 | C 10 | CC 0 | ( 0) | T_STRING                   | [  4]: name
- 10 | L04 | C 14 | CC 0 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
- 11 | L04 | C 15 | CC 0 | ( 1) | T_VARIABLE                 | [  6]: $param
- 12 | L04 | C 21 | CC 0 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
- 13 | L04 | C 22 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
- 14 | L04 | C 23 | CC 0 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
- 15 | L04 | C 24 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
-
- 16 | L05 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱ | Orig: →
- 17 | L05 | C  5 | CC 1 | ( 0) | T_IF                       | [  2]: if
- 18 | L05 | C  7 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
- 19 | L05 | C  8 | CC 1 | ( 0) | T_OPEN_PARENTHESIS         | [  1]: (
- 20 | L05 | C  9 | CC 1 | ( 1) | T_VARIABLE                 | [ 10]: $condition
- 21 | L05 | C 19 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
- 22 | L05 | C 20 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
- 23 | L05 | C 23 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
- 24 | L05 | C 24 | CC 1 | ( 1) | T_CONSTANT_ENCAPSED_STRING | [  7]: 'q⸱⸱⸱a' | Orig: 'q→a'
- 25 | L05 | C 31 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
- 26 | L05 | C 32 | CC 1 | ( 1) | T_BOOLEAN_AND              | [  2]: &&
- 27 | L05 | C 34 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
- 28 | L05 | C 35 | CC 1 | ( 1) | T_VARIABLE                 | [  6]: $param
- 29 | L05 | C 41 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
- 30 | L05 | C 42 | CC 1 | ( 1) | T_IS_IDENTICAL             | [  3]: ===
- 31 | L05 | C 45 | CC 1 | ( 1) | T_WHITESPACE               | [  1]: ⸱
- 32 | L05 | C 46 | CC 1 | ( 1) | T_FALSE                    | [  5]: false
- 33 | L05 | C 51 | CC 1 | ( 0) | T_CLOSE_PARENTHESIS        | [  1]: )
- 34 | L05 | C 52 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
- 35 | L05 | C 53 | CC 1 | ( 0) | T_OPEN_CURLY_BRACKET       | [  1]: {
- 36 | L05 | C 54 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
-
- 37 | L06 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  8]: ⸱⸱⸱⸱⸱⸱⸱⸱
- 38 | L06 | C  9 | CC 2 | ( 0) | T_COMMENT                  | [ 16]: /* Do something.
-
- 39 | L07 | C  1 | CC 2 | ( 0) | T_COMMENT                  | [ 24]: ⸱⸱⸱⸱⸱⸱⸱⸱⸱*⸱Multi-line⸱*/ | Orig: →→⸱*⸱Multi-line⸱*/
- 40 | L07 | C 25 | CC 2 | ( 0) | T_WHITESPACE               | [  0]:
-
- 41 | L08 | C  1 | CC 2 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
- 42 | L08 | C  5 | CC 1 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
- 43 | L08 | C  6 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
-
- 44 | L09 | C  1 | CC 1 | ( 0) | T_WHITESPACE               | [  4]: ⸱⸱⸱⸱
- 45 | L09 | C  5 | CC 1 | ( 0) | T_RETURN                   | [  6]: return
- 46 | L09 | C 11 | CC 1 | ( 0) | T_WHITESPACE               | [  1]: ⸱
- 47 | L09 | C 12 | CC 1 | ( 0) | T_VARIABLE                 | [  3]: $cl
- 48 | L09 | C 15 | CC 1 | ( 0) | T_SEMICOLON                | [  1]: ;
- 49 | L09 | C 16 | CC 1 | ( 0) | T_WHITESPACE               | [  0]:
-
- 50 | L10 | C  1 | CC 0 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
- 51 | L10 | C  2 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
-
-
-EOD;
+        if (version_compare(Config::VERSION, '3.99.99', '>') === true) {
+            // As of PHPCS 4.0, whitespace after the long PHP open tag is tokenized separately,
+            // hence the difference in test expectations.
+            $expected = file_get_contents(__DIR__ . '/TokenListExpectationPhpcs4.txt');
+        } else {
+            $expected = file_get_contents(__DIR__ . '/TokenListExpectationPhpcs3.txt');
+        }
 
         if (empty(self::$phpcsFile->ruleset->tokenListeners)) {
             // PHPCSUtils 1.0.9+.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.1.0",
+        "squizlabs/php_codesniffer" : "^3.1.0 || ^4.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
PHPCSDevTools currently only contains one tool which has a dependency on PHPCS: PHPCSDebug.

PHPCSDebug is already compatible with PHPCS 4.0, no changed needed. The only thing which does need a change is the test expectations as the tokenization of the PHP open tag has changed in PHPCS 4.0, which means the output expectation will be different between PHPCS 3.x vs 4.x.

Includes:
* Explicitly declaring compatibility with PHPCS 4.0 in the `composer.json` file.
* Updating the workflows to use the new PHPCS 4.x branch for testing.
* Updating the workflow to structurally test against both PHPCS 3.x as well as 4.x.
* Not allowing builds against PHPCS 4.x to fail anymore.