### PR TITLE
GH Actions: add build against "low" PHPCS for PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,8 @@ jobs:
             phpcs_version: '3.8.0'
           - php: '8.4'
             phpcs_version: '3.8.0'
+          - php: '8.5'
+            phpcs_version: '3.13.4'
 
     name: "Test: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 


### PR DESCRIPTION
As things are at this time, it looks like PHPCS 3.13.4 will be the first PHPCS version to be runtime compatible with PHP 8.5.

The caveat to this is that not all PHP 8.5 deprecations have been merged into PHP Core yet, so this minimum PHPCS version may need further updates later on if further changes in PHPCS would be needed.
