### PR TITLE
GH Actions: update for final PHPCS 4.0.0 release and main branch rename

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -39,8 +39,9 @@ jobs:
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
           composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
-          # Using PHPCS `master` as an early detection system for bugs upstream.
-          composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
+          # Using PHPCS `3.x` as an early detection system for bugs upstream.
+          # This should be changed to 4.x, but we'll need to wait for PHPCSDevCS to be compatible with 4.x.
+          composer require --no-update squizlabs/php_codesniffer:"3.x-dev" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['3.1.0', 'dev-master']
+        phpcs_version: ['3.1.0', '3.x-dev']
 
         exclude:
           # PHP 3.1.0 is incompatible with PHP >= 8.0.
@@ -108,7 +108,11 @@ jobs:
             phpcs_version: '3.8.0'
 
           - php: '7.2'
+            phpcs_version: '4.0.0'
+          - php: '7.2'
             phpcs_version: '4.x-dev'
+          - php: 'latest'
+            phpcs_version: '4.0.0'
           - php: 'latest'
             phpcs_version: '4.x-dev'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,17 +113,27 @@ jobs:
         #
         # Additionally, PHPCS 4.x has a minimum version requirement of PHP 7.2.
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
-        phpcs_version: ['dev-master', '4.x-dev']
+        phpcs_version: ['3.x-dev', '4.0.0', '4.x-dev']
 
         exclude:
           - php: '5.4'
+            phpcs_version: '4.0.0'
+          - php: '5.4'
             phpcs_version: '4.x-dev'
+          - php: '5.5'
+            phpcs_version: '4.0.0'
           - php: '5.5'
             phpcs_version: '4.x-dev'
           - php: '5.6'
+            phpcs_version: '4.0.0'
+          - php: '5.6'
             phpcs_version: '4.x-dev'
           - php: '7.0'
+            phpcs_version: '4.0.0'
+          - php: '7.0'
             phpcs_version: '4.x-dev'
+          - php: '7.1'
+            phpcs_version: '4.0.0'
           - php: '7.1'
             phpcs_version: '4.x-dev'
 


### PR DESCRIPTION
* Change `dev-master` to `3.x-dev`.
* Add explicit runs against the lowest supported PHPCS 4.x version - currently `4.0.0`.