### PR TITLE
Composer: update to PHPCSDevCS 1.2.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -39,9 +39,8 @@ jobs:
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
           composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
-          # Using PHPCS `3.x` as an early detection system for bugs upstream.
-          # This should be changed to 4.x, but we'll need to wait for PHPCSDevCS to be compatible with 4.x.
-          composer require --no-update squizlabs/php_codesniffer:"3.x-dev" --no-interaction
+          # Using PHPCS `4.x` as an early detection system for bugs upstream.
+          composer require --no-update squizlabs/php_codesniffer:"4.x-dev" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/Tests/IOTestCase.php
+++ b/Tests/IOTestCase.php
@@ -47,9 +47,9 @@ abstract class IOTestCase extends XTestCase
         }
 
         $descriptorspec = [
-            0 => ['pipe', 'r'],  // stdin
-            1 => ['pipe', 'w'],  // stdout
-            2 => ['pipe', 'w'],  // stderr
+            0 => ['pipe', 'r'], // stdin
+            1 => ['pipe', 'w'], // stdout
+            2 => ['pipe', 'w'], // stderr
         ];
 
         $options = null;

--- a/bin/phpcs-check-feature-completeness
+++ b/bin/phpcs-check-feature-completeness
@@ -31,9 +31,9 @@
  * @link      https://github.com/PHPCSStandards/PHPCSDevTools
  */
 
-if (is_file(__DIR__.'/../autoload.php') === true) {
+if (is_file(__DIR__ . '/../autoload.php') === true) {
     // Installed via Composer.
-    require_once __DIR__.'/../autoload.php';
+    require_once __DIR__ . '/../autoload.php';
 } else {
     // Presume git clone.
     require_once __DIR__ . '/../Scripts/FileList.php';

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpunit/phpunit" : "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "php-parallel-lint/php-console-highlighter": "^1.0.0",
-        "phpcsstandards/phpcsdevcs": "^1.1.6",
+        "phpcsstandards/phpcsdevcs": "^1.2.0",
         "phpcsstandards/phpcsutils" : "^1.0",
         "yoast/phpunit-polyfills": "^1.1 || ^2.0 || ^3.0"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
     -->
 
     <file>.</file>
+    <file>./bin/phpcs-check-feature-completeness</file>
 
     <!-- Exclude Composer vendor directory. -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
@@ -33,12 +34,11 @@
     -->
 
     <rule ref="PHPCSDev">
-        <!-- Allow for the file docblock on the line directly following the PHP open tag.
-             As the sniff in PHPCS does not use modular error codes (yet - see PR #2729),
-             the complete error code needs to be disabled, not just the bit involving
-             the file docblocks.
-        -->
+        <!-- Only needed for PHPCS 3.x. This exclusion can be removed when PHPCSDevCS drops support for PHPCS 3.x. -->
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
+
+        <!-- Temporary exclude. Changing pre-existing classes to final can only be done in a major release. -->
+        <exclude name="Universal.Classes.RequireFinalClass"/>
     </rule>
 
     <!-- Set minimum PHP version supported to PHP 5.4. -->


### PR DESCRIPTION
### Composer: update to PHPCSDevCS 1.2.0

PHPCSDevCS allows for PHPCS 4.0 and includes PHPCompatibility 10.0.0-alpha1 and a range of sniffs from PHPCSExtra.

This also means that we can now scan files without a file extension (if explicitly requested), so the `bin` script can now be scanned.

Includes minor documentation update in the ruleset and some small CS fixes.

Refs:
* https://github.com/PHPCSStandards/PHPCSDevCS/releases/tag/1.2.0
* squizlabs/PHP_CodeSniffer#2916
* PHPCSStandards/PHP_CodeSniffer#1022

### GH Actions: run CS check against PHPCS 4.x dev 