### PR TITLE
Composer: remove roave/security-advisories suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {
-        "roave/security-advisories" : "dev-master",
         "phpunit/phpunit" : "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "php-parallel-lint/php-console-highlighter": "^1.0.0",


### PR DESCRIPTION
The `roave/security-advisories` package was an inventive method to block installation of known insecure versions of other dependencies (via a `conflict` annotation).

As of Composer 2.9, using the `roave/security-advisories` package for this purpose is no longer needed as Composer will now natively block installation of known insecure versions of dependencies.

And while not all contributors to this repo may be using Composer 2.9+ (yet), Composer 2.9+ **_will_** be used in CI and CI failing on Composer blocking an insecure dependency offers the same level of protection as the package previously offered.

Refs:
* https://blog.packagist.com/composer-2-9/
* https://github.com/composer/composer/releases/tag/2.9.0