### PR TITLE
Dependabot: fix config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "cron"
-      cronjob: "10 22 5,20 * *" # At 22:10, every 5th and 20th day of the month.
+      interval: "weekly"
     open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
     versioning-strategy: widen
     commit-message:
@@ -21,7 +20,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "cron"
+      cronjob: "10 22 5,20 * *" # At 22:10, every 5th and 20th day of the month.
     open-pull-requests-limit: 5
     target-branch: "stable"
     commit-message:


### PR DESCRIPTION
Follow up on #212, which changed the schedule/interval for the wrong "package-ecosystem". That PR was intended to change the GH Actions PRs, not the Composer related PRs.